### PR TITLE
fix: use pnpm publish with prerelease tag detection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           curl -f http://localhost:3100/health
           docker stop waiaas-release-test
 
-  # npm publish dry-run for all 8 publishable packages
+  # pnpm publish dry-run for all 8 publishable packages
   publish-check:
     runs-on: ubuntu-latest
     needs: test
@@ -133,7 +133,7 @@ jobs:
       - name: Build
         run: pnpm turbo run build
 
-      - name: npm publish dry-run
+      - name: pnpm publish dry-run
         run: |
           PACKAGES=(
             packages/core
@@ -148,7 +148,7 @@ jobs:
           for pkg_path in "${PACKAGES[@]}"; do
             echo "--- Checking $pkg_path ---"
             cd "$pkg_path"
-            npm publish --dry-run 2>&1 || exit 1
+            pnpm publish --dry-run --no-git-checks 2>&1 || exit 1
             cd "$GITHUB_WORKSPACE"
           done
 
@@ -210,7 +210,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Gate 2: Manual approval deploy — npm publish + summary
+  # Gate 2: Manual approval deploy — pnpm publish + summary
   deploy:
     runs-on: ubuntu-latest
     needs: [test, chain-integration, platform, publish-check, docker-publish]
@@ -231,7 +231,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: npm publish
+      - name: pnpm publish
         run: |
           PACKAGES=(
             packages/core
@@ -246,7 +246,12 @@ jobs:
           for pkg_path in "${PACKAGES[@]}"; do
             echo "--- Publishing $pkg_path ---"
             cd "$pkg_path"
-            npm publish --access public 2>&1
+            PKG_VERSION=$(node -p "require('./package.json').version")
+            if [[ "$PKG_VERSION" == *-* ]]; then
+              pnpm publish --access public --no-git-checks --tag rc 2>&1
+            else
+              pnpm publish --access public --no-git-checks 2>&1
+            fi
             cd "$GITHUB_WORKSPACE"
           done
         env:

--- a/internal/objectives/issues/081-npm-publish-rc-latest-tag.md
+++ b/internal/objectives/issues/081-npm-publish-rc-latest-tag.md
@@ -1,0 +1,67 @@
+# 081 — npm publish에서 RC 버전이 latest 태그로 배포됨
+
+| 필드 | 값 |
+|------|-----|
+| **유형** | BUG |
+| **심각도** | HIGH |
+| **마일스톤** | v2.3 |
+| **상태** | FIXED |
+| **발견일** | 2026-02-18 |
+
+## 증상
+
+`npm install -g @waiaas/cli` 실행 시 RC 버전(`2.1.3-rc.1`)이 설치된다. `npm view @waiaas/cli dist-tags` 결과:
+
+```
+{ latest: '2.1.3-rc.1' }
+```
+
+RC 버전은 `rc` 또는 `next` 태그로 배포되어야 하며, `latest`는 정식 릴리스만 가리켜야 한다.
+
+## 원인
+
+`release.yml:249`에서 `--tag` 옵션 없이 publish:
+
+```bash
+npm publish --access public 2>&1
+```
+
+npm은 `--tag`를 생략하면 자동으로 `latest` 태그를 부여한다. 버전 문자열에 prerelease 접미사(`-rc`, `-beta`, `-alpha`)가 있어도 무조건 `latest`로 올라간다.
+
+## 수정 방안
+
+publish 전에 버전 문자열을 검사하여 `--tag` 분기:
+
+```bash
+for pkg_path in "${PACKAGES[@]}"; do
+  echo "--- Publishing $pkg_path ---"
+  cd "$pkg_path"
+  PKG_VERSION=$(node -p "require('./package.json').version")
+  if [[ "$PKG_VERSION" == *-* ]]; then
+    # prerelease: -rc.1, -beta.2, -alpha.1 등
+    npm publish --access public --tag rc 2>&1
+  else
+    # 정식 릴리스
+    npm publish --access public 2>&1
+  fi
+  cd "$GITHUB_WORKSPACE"
+done
+```
+
+semver에서 `-` 이후 문자열이 있으면 prerelease이므로 `*-*` 패턴으로 판별 가능.
+
+## 즉시 복구
+
+현재 `latest`가 RC를 가리키는 상태를 수동으로 복구하려면, 정식 버전이 배포된 후:
+
+```bash
+npm dist-tag add @waiaas/cli@<정식버전> latest
+npm dist-tag add @waiaas/cli@2.1.3-rc.1 rc
+```
+
+또는 정식 릴리스를 한 번 publish하면 `latest`가 자동으로 정식 버전으로 이동한다.
+
+## 영향 범위
+
+- `.github/workflows/release.yml` — deploy job의 npm publish 단계
+- 8개 패키지 전체 동일 영향: core, daemon, cli, sdk, mcp, skills, adapter-solana, adapter-evm

--- a/internal/objectives/issues/082-npm-publish-workspace-protocol.md
+++ b/internal/objectives/issues/082-npm-publish-workspace-protocol.md
@@ -1,0 +1,75 @@
+# 082 — release.yml이 npm publish 사용하여 workspace:* 미치환 상태로 배포됨
+
+| 필드 | 값 |
+|------|-----|
+| **유형** | BUG |
+| **심각도** | CRITICAL |
+| **마일스톤** | v2.3 |
+| **상태** | FIXED |
+| **발견일** | 2026-02-18 |
+
+## 증상
+
+`npm install -g @waiaas/cli` 실행 시 설치 실패:
+
+```
+npm error code EUNSUPPORTEDPROTOCOL
+npm error Unsupported URL Type "workspace:": workspace:*
+```
+
+배포된 패키지의 dependencies에 `workspace:*`가 그대로 남아있다:
+
+```json
+{
+  "@waiaas/core": "workspace:*",
+  "@waiaas/daemon": "workspace:*"
+}
+```
+
+## 원인
+
+`release.yml:249`에서 `npm publish`를 사용:
+
+```bash
+npm publish --access public 2>&1
+```
+
+`npm publish`는 pnpm의 `workspace:*` 프로토콜을 인식하지 못하고 package.json을 그대로 배포한다. `pnpm publish`를 사용해야 `workspace:*`가 실제 버전 번호(예: `^2.1.3-rc.1`)로 자동 치환된다.
+
+## 관련 이슈
+
+- 이슈 076 (FIXED): Smoke Test에서 동일 문제 발견 → 로컬 테스트는 `pnpm pack`으로 수정됨
+- 그러나 실제 CI의 `release.yml` publish 단계에는 반영되지 않았음
+
+## 수정 방안
+
+`release.yml`의 npm publish를 pnpm publish로 변경:
+
+```bash
+for pkg_path in "${PACKAGES[@]}"; do
+  echo "--- Publishing $pkg_path ---"
+  cd "$pkg_path"
+  pnpm publish --access public --no-git-checks 2>&1
+  cd "$GITHUB_WORKSPACE"
+done
+```
+
+`pnpm publish`는:
+1. `workspace:*` → 실제 버전으로 치환
+2. `workspace:^` → `^실제버전`으로 치환
+3. 치환된 임시 package.json으로 publish 후 원본 복원
+
+## 즉시 복구
+
+현재 배포된 8개 패키지 전부 설치 불가 상태. 수정 후 재배포 필요:
+
+```bash
+# CI에서 pnpm publish로 재배포하거나, 로컬에서 수동 복구:
+pnpm publish --access public --no-git-checks
+```
+
+## 영향 범위
+
+- `.github/workflows/release.yml` — deploy job의 publish 단계
+- 8개 패키지 전체: core, daemon, cli, sdk, mcp, skills, adapter-solana, adapter-evm
+- **모든 사용자가 npm install로 설치 불가** — CRITICAL

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -95,6 +95,8 @@
 | 078 | BUG | HIGH | Smoke Test 워크스페이스 상호 의존 패키지 설치 순서 오류 + CLI ESM import 부적절 | v2.2 | FIXED | 2026-02-18 |
 | 079 | ENHANCEMENT | MEDIUM | vitest 고아 프로세스 재발 방지 — 전 패키지 forceExit + forks pool 통일 | v2.2 | FIXED | 2026-02-18 |
 | 080 | BUG | MEDIUM | Graceful Shutdown 후 process.exit(0) 미호출로 프로세스 미종료 | v2.2 | FIXED | 2026-02-18 |
+| 081 | BUG | HIGH | npm publish에서 RC 버전이 latest 태그로 배포됨 | v2.3 | FIXED | 2026-02-18 |
+| 082 | BUG | CRITICAL | release.yml이 npm publish 사용하여 workspace:* 미치환 상태로 배포됨 | v2.3 | FIXED | 2026-02-18 |
 
 ## Type Legend
 
@@ -107,7 +109,7 @@
 ## Summary
 
 - **OPEN:** 0
-- **FIXED:** 80
+- **FIXED:** 82
 - **VERIFIED:** 0
 - **WONTFIX:** 0
-- **Total:** 80
+- **Total:** 82


### PR DESCRIPTION
## Summary
- Replace `npm publish` with `pnpm publish --no-git-checks` to resolve `workspace:*` protocol substitution failure (issue #082, CRITICAL)
- Add `--tag rc` for prerelease versions to prevent RC builds from overriding the `latest` dist-tag (issue #081, HIGH)
- Update dry-run check to use `pnpm publish --dry-run` for consistency

## Changes
| Before | After |
|--------|-------|
| `npm publish --access public` | `pnpm publish --access public --no-git-checks` |
| No tag detection | `--tag rc` for prerelease (`*-*` pattern) |
| `npm publish --dry-run` | `pnpm publish --dry-run --no-git-checks` |

## Test plan
- [ ] CI workflow passes (lint, typecheck, tests)
- [ ] `pnpm publish --dry-run --no-git-checks` succeeds in publish-check job
- [ ] Verify prerelease tag detection: version with `-` suffix gets `--tag rc`
- [ ] Verify stable version publishes without `--tag` (defaults to `latest`)
- [ ] Confirm `workspace:*` dependencies are resolved in published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)