### PR TITLE
fix(ci): resolve daemon path without exports subpath in smoke test

### DIFF
--- a/scripts/smoke-test-published.sh
+++ b/scripts/smoke-test-published.sh
@@ -108,7 +108,7 @@ verify_import "@waiaas/adapter-evm" "import { EvmAdapter } from '@waiaas/adapter
 # Step 5: Verify Admin UI in daemon package
 echo ""
 echo "--- Verifying Admin UI in daemon package ---"
-DAEMON_DIR=$(node -e "const p=require.resolve('@waiaas/daemon/package.json');console.log(require('path').dirname(p))")
+DAEMON_DIR="./node_modules/@waiaas/daemon"
 if [ -f "$DAEMON_DIR/public/admin/index.html" ]; then
   echo "  ✓ Admin UI (public/admin/index.html)"
   PASSED=$((PASSED + 1))


### PR DESCRIPTION
## Summary
- Fix smoke test `ERR_PACKAGE_PATH_NOT_EXPORTED` error when resolving `@waiaas/daemon/package.json`
- Use deterministic `./node_modules/@waiaas/daemon` path instead of `require.resolve` with unexported subpath

## Root Cause
The daemon's `exports` field only exposes `.` (mapped to `./dist/index.js`), not `./package.json`. The smoke test used `require.resolve('@waiaas/daemon/package.json')` which fails on Node.js 22 with strict exports enforcement.

## Test plan
- [ ] CI release pipeline smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)