### PR TITLE
Milestone v28.7: Agent zero-state setup skill + guide lightweight

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,16 @@ For agents that don't support MCP, or when you prefer REST API integration:
 npx @waiaas/skills add all
 ```
 
-This adds `.skill.md` instruction files to your project. Include them in your agent's context and it learns the WAIaaS API automatically. Available skills: `quickstart`, `wallet`, `transactions`, `policies`, `admin`, `actions`, `x402`.
+This adds `.skill.md` instruction files to your project. Include them in your agent's context and it learns the WAIaaS API automatically. Available skills: `setup`, `quickstart`, `wallet`, `transactions`, `policies`, `admin`, `actions`, `x402`.
+
+### Agent Self-Setup
+
+AI agents can set up WAIaaS from scratch by following the setup skill:
+
+1. Install skills: `npx @waiaas/skills add all`
+2. Read and follow `waiaas-setup/SKILL.md`
+
+The setup skill guides through CLI installation, daemon startup, wallet creation, and session configuration. Master password prompts require human input.
 
 ## Alternative: Docker
 

--- a/docs/guides/agent-skills-integration.md
+++ b/docs/guides/agent-skills-integration.md
@@ -20,24 +20,15 @@ Agent Skills is an open standard for AI agent capability files. Platforms that s
 | Claude Code | `.claude/skills/` | Use `npx @waiaas/skills claude-code` instead |
 | OpenClaw | `~/.openclaw/skills/` | Use `npx @waiaas/skills openclaw` instead |
 
-## Prerequisites
-
-- WAIaaS daemon installed and running (`npx @waiaas/daemon` or `waiaas start`)
-- An AI agent platform that supports Agent Skills
-
 ## Quick Setup
 
-### 1. Create Wallets and Sessions
+### 1. Initial Setup
 
-```bash
-waiaas quickset
-```
-
-This creates Solana + EVM wallets in mainnet mode and prints session tokens.
+If WAIaaS is not yet installed, follow the `setup` skill (`waiaas-setup/SKILL.md`) for CLI installation, daemon startup, wallet creation, and session configuration.
 
 ### 2. Install WAIaaS Skills
 
-**Default (Codex, Gemini CLI, Goose, Amp):**
+**Default (Codex, Gemini CLI, Goose, Amp, Roo Code):**
 
 ```bash
 npx @waiaas/skills agent-skills
@@ -61,32 +52,11 @@ npx @waiaas/skills agent-skills --target github
 
 Installs to `.github/skills/waiaas-*/SKILL.md`.
 
-### 3. Configure Environment Variables
-
-Set these environment variables for your AI agent:
-
-```bash
-export WAIAAS_BASE_URL=http://localhost:3100
-export WAIAAS_SESSION_TOKEN=<your-session-token>
-```
-
-The agent no longer needs the master password. Provide only the session token from step 1.
-
-### 4. Environment Auto-Discovery
-
-With connect-info, the agent can discover capabilities without loading skill files. On startup, call:
-
-```bash
-curl -s http://localhost:3100/v1/connect-info \
-  -H 'Authorization: Bearer $WAIAAS_SESSION_TOKEN'
-```
-
-This returns all accessible wallets, policies, and capabilities with an AI-ready prompt, enabling automatic environment discovery.
-
 ## Available Skills
 
 | Skill | Description |
 |-------|-------------|
+| `waiaas-setup` | Zero-state daemon setup: install CLI, initialize, start daemon, create wallet, configure session |
 | `waiaas-quickstart` | End-to-end quickset: create wallet, session, check balance, send first transfer |
 | `waiaas-wallet` | Wallet CRUD, asset queries, session management, token registry, MCP provisioning |
 | `waiaas-transactions` | All 5 transaction types (TRANSFER, TOKEN_TRANSFER, CONTRACT_CALL, APPROVE, BATCH) |

--- a/docs/guides/claude-code-integration.md
+++ b/docs/guides/claude-code-integration.md
@@ -2,20 +2,11 @@
 
 This guide walks you through connecting WAIaaS to [Claude Code](https://claude.ai/claude-code), Anthropic's official CLI for Claude. WAIaaS provides two integration methods: skill files and MCP server.
 
-## Prerequisites
-
-- WAIaaS daemon installed and running (`npx @waiaas/daemon` or `waiaas start`)
-- Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
-
 ## Quick Setup
 
-### 1. Create Wallets and Sessions
+### 1. Initial Setup
 
-```bash
-waiaas quickset
-```
-
-This creates Solana + EVM wallets in mainnet mode and prints session tokens and MCP configuration.
+If WAIaaS is not yet installed, follow the `setup` skill (`waiaas-setup/SKILL.md`) for CLI installation, daemon startup, wallet creation, and session configuration.
 
 ### 2. Install WAIaaS Skills
 
@@ -23,10 +14,11 @@ This creates Solana + EVM wallets in mainnet mode and prints session tokens and 
 npx @waiaas/skills claude-code
 ```
 
-This installs 7 WAIaaS skill files to `.claude/skills/` in your project directory:
+This installs 8 WAIaaS skill files to `.claude/skills/` in your project directory:
 
 ```
 .claude/skills/
+  waiaas-setup/SKILL.md
   waiaas-quickstart/SKILL.md
   waiaas-wallet/SKILL.md
   waiaas-transactions/SKILL.md
@@ -90,6 +82,7 @@ You can use both simultaneously. Skills provide comprehensive API documentation 
 
 | Skill | Description |
 |-------|-------------|
+| `waiaas-setup` | Zero-state daemon setup: install CLI, initialize, start daemon, create wallet, configure session |
 | `waiaas-quickstart` | End-to-end quickset: create wallet, session, check balance, send first transfer |
 | `waiaas-wallet` | Wallet CRUD, asset queries, session management, token registry, MCP provisioning |
 | `waiaas-transactions` | All 5 transaction types (TRANSFER, TOKEN_TRANSFER, CONTRACT_CALL, APPROVE, BATCH) |

--- a/docs/guides/openclaw-integration.md
+++ b/docs/guides/openclaw-integration.md
@@ -2,26 +2,11 @@
 
 This guide walks you through connecting WAIaaS to [OpenClaw](https://openclaw.io), an open-source AI agent bot that follows the Agent Skills open standard.
 
-## Prerequisites
-
-- WAIaaS daemon installed and running (`npx @waiaas/daemon` or `waiaas start`)
-- OpenClaw installed and configured
-
 ## Quick Setup
 
-### 1. Create Wallets and Sessions
+### 1. Initial Setup
 
-```bash
-waiaas quickset
-```
-
-This creates Solana + EVM wallets in mainnet mode and prints session tokens and MCP configuration.
-
-For testnet mode:
-
-```bash
-waiaas quickset --mode testnet
-```
+If WAIaaS is not yet installed, follow the `setup` skill (`waiaas-setup/SKILL.md`) for CLI installation, daemon startup, wallet creation, and session configuration.
 
 ### 2. Install WAIaaS Skills
 
@@ -29,10 +14,11 @@ waiaas quickset --mode testnet
 npx @waiaas/skills openclaw
 ```
 
-This installs 7 WAIaaS skill files to `~/.openclaw/skills/`:
+This installs 8 WAIaaS skill files to `~/.openclaw/skills/`:
 
 ```
 ~/.openclaw/skills/
+  waiaas-setup/SKILL.md
   waiaas-quickstart/SKILL.md
   waiaas-wallet/SKILL.md
   waiaas-transactions/SKILL.md
@@ -86,6 +72,7 @@ OpenClaw will use the `waiaas-quickstart` skill to query the daemon and return y
 
 | Skill | Description |
 |-------|-------------|
+| `waiaas-setup` | Zero-state daemon setup: install CLI, initialize, start daemon, create wallet, configure session |
 | `waiaas-quickstart` | End-to-end quickset: create wallet, session, check balance, send first transfer |
 | `waiaas-wallet` | Wallet CRUD, asset queries, session management, token registry, MCP provisioning |
 | `waiaas-transactions` | All 5 transaction types (TRANSFER, TOKEN_TRANSFER, CONTRACT_CALL, APPROVE, BATCH) |

--- a/internal/objectives/issues/189-agent-zero-setup-skill.md
+++ b/internal/objectives/issues/189-agent-zero-setup-skill.md
@@ -1,0 +1,102 @@
+# 189 — 에이전트 Zero-State 셋업 스킬 + 가이드 경량화
+
+- **유형:** ENHANCEMENT
+- **심각도:** HIGH
+- **마일스톤:** v28.7
+
+## 현황
+
+현재 `docs/guides/` 가이드 문서 3개(agent-skills, claude-code, openclaw)는 WAIaaS 데몬이 이미 설치·실행 중임을 전제한다. 최신 AI 에이전트는 패키지 설치부터 초기 설정까지 자율적으로 수행할 수 있으므로, zero-state(아무것도 설치되지 않은 상태)에서 에이전트가 스스로 셋업을 완료할 수 있는 경로가 필요하다.
+
+## 요구사항
+
+### 1. `setup.skill.md` 신규 생성
+
+CLI 기반 zero-state 셋업 스킬. 에이전트가 이 스킬을 읽고 따라하면 초기 설정이 완료되는 구조.
+
+**흐름:**
+```
+1. CLI 설치 확인: which waiaas || npm install -g @waiaas/cli
+2. 데몬 초기화: waiaas init
+3. 데몬 시작: waiaas start        ← master password 프롬프트 → 사용자 입력 대기
+4. 지갑+세션 생성: waiaas quickset  ← master password 프롬프트 → 사용자 입력 대기
+5. 세션 토큰 캡처 → 환경변수 설정
+6. 스킬 설치: npx @waiaas/skills <platform>
+```
+
+**핵심 안내 사항:**
+- `waiaas start` (첫 실행)과 `waiaas quickset` 실행 시 master password 입력 프롬프트가 표시됨
+- master password는 사람만 알아야 하는 값 — 에이전트는 프롬프트가 뜨면 사용자 입력을 기다려야 함
+- 에이전트는 master password를 절대 요청하거나 저장하지 않음
+- 출력된 세션 토큰만 캡처하여 이후 작업에 사용
+
+**포함할 내용:**
+- Node.js 22+ 사전 요구사항
+- CLI 설치 (`npm install -g @waiaas/cli`)
+- `waiaas init` → `waiaas start` → `waiaas quickset` 순서
+- 환경변수 설정 (WAIAAS_BASE_URL, WAIAAS_SESSION_TOKEN)
+- connect-info 자기 발견 호출
+- 다음 단계 안내 (다른 스킬 참조)
+
+### 2. 가이드 문서 3개 경량화
+
+기존 가이드에서 공통 설정 로직을 제거하고 setup 스킬로 위임. 플랫폼 고유 사항만 유지.
+
+**변경 패턴:**
+```markdown
+## Quick Setup
+
+### 1. Install WAIaaS Skills
+npx @waiaas/skills <platform>
+
+### 2. Initial Setup
+Follow `waiaas-setup/SKILL.md` for daemon installation,
+wallet creation, and session configuration.
+
+### 3. (Platform-specific features)
+```
+
+**대상 파일:**
+- `docs/guides/agent-skills-integration.md` — Prerequisites 경량화, 공통 설정을 setup 스킬로 위임
+- `docs/guides/claude-code-integration.md` — 위와 동일 + MCP 고유 내용만 유지
+- `docs/guides/openclaw-integration.md` — 위와 동일 + openclaw.json 고유 내용만 유지
+
+### 3. README 업데이트
+
+"Connect Your AI Agent" 섹션에 setup 스킬 참조 추가. 에이전트가 README를 읽었을 때 "스킬을 보고 초기화하면 된다"는 진입점을 제공.
+
+**추가할 내용 (예시):**
+```markdown
+### Agent Self-Setup
+
+AI agents can set up WAIaaS from scratch by following the setup skill:
+
+1. Install skills: `npx @waiaas/skills add all`
+2. Read and follow `waiaas-setup/SKILL.md`
+
+The setup skill guides through CLI installation, daemon startup, wallet creation,
+and session configuration. Master password prompts require human input.
+```
+
+### 4. skills 패키지에 setup 스킬 등록
+
+- `skills/setup.skill.md` 생성 (루트)
+- `packages/skills/skills/setup.skill.md` 동기 (npm 배포용)
+- skills installer가 setup 스킬을 포함하도록 확인
+
+## 설계 결정
+
+| ID | 결정 | 근거 |
+|----|------|------|
+| D1 | CLI 패키지 기반 셋업 (데몬 직접 실행 X) | 에이전트가 CLI를 통해 데몬을 제어할 수 있어 이후 운영에도 활용 가능 |
+| D2 | master password는 인터랙티브 프롬프트로만 입력 | 보안 경계 유지 — 에이전트 컨텍스트에 패스워드가 남지 않음 |
+| D3 | 가이드 → 스킬 위임 구조 | 스킬이 SSoT — 내용 중복 제거, 스킬 업데이트 시 가이드 자동 반영 |
+| D4 | 스킬 설치를 셋업 흐름 마지막에 배치 | 데몬이 먼저 실행되어야 스킬의 curl/CLI 명령이 동작함 |
+
+## 테스트 항목
+
+- [ ] `setup.skill.md` frontmatter 유효성 (name, description, category, tags, version, dispatch)
+- [ ] 가이드 문서 3개에서 setup 스킬 참조 링크가 올바른지 확인
+- [ ] README "Agent Self-Setup" 섹션이 정확한 명령어를 포함하는지 확인
+- [ ] `skills/setup.skill.md`와 `packages/skills/skills/setup.skill.md` 내용 동기화
+- [ ] 기존 스킬 목록(Available Skills 테이블)에 setup 스킬 추가 여부 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -203,6 +203,7 @@
 | 186 | BUG | CRITICAL | LI.FI getQuote 쿼리 파라미터명 오류로 스왑/브릿지 전체 실패 | v28.5 | FIXED | 2026-02-25 |
 | 187 | BUG | HIGH | 솔라나 메인넷 잔액 조회 429 실패 — 무료 RPC rate limit + 재시도 로직 부재 | v28.5 | FIXED | 2026-02-25 |
 | 188 | BUG | HIGH | Admin UI Actions 프로바이더가 항상 Inactive — `/v1/actions/*` 와일드카드 sessionAuth 충돌 | v28.5 | FIXED | 2026-02-25 |
+| 189 | ENHANCEMENT | HIGH | 에이전트 Zero-State 셋업 스킬 + 가이드 경량화 + README 진입점 | v28.7 | FIXED | 2026-02-25 |
 
 ## Type Legend
 
@@ -215,8 +216,8 @@
 ## Summary
 
 - **OPEN:** 0
-- **FIXED:** 187
+- **FIXED:** 188
 - **RESOLVED:** 0
 - **VERIFIED:** 0
 - **WONTFIX:** 1
-- **Total:** 188
+- **Total:** 189

--- a/packages/skills/src/registry.ts
+++ b/packages/skills/src/registry.ts
@@ -8,6 +8,12 @@ export interface SkillEntry {
 
 export const SKILL_REGISTRY: readonly SkillEntry[] = [
   {
+    name: "setup",
+    filename: "setup.skill.md",
+    description:
+      "Zero-state daemon setup: install CLI, initialize, start daemon, create wallet, configure session",
+  },
+  {
     name: "quickstart",
     filename: "quickstart.skill.md",
     description:

--- a/skills/setup.skill.md
+++ b/skills/setup.skill.md
@@ -1,0 +1,195 @@
+---
+name: "WAIaaS Setup"
+description: "Zero-state daemon setup: install CLI, initialize, start daemon, create wallet, configure session"
+category: "api"
+tags: [wallet, blockchain, solana, ethereum, setup, install, waiass]
+version: "2.5.0-rc"
+dispatch:
+  kind: "tool"
+  allowedCommands: ["curl", "npm", "npx", "waiaas", "which"]
+---
+
+# WAIaaS Zero-State Setup
+
+This skill guides you through setting up WAIaaS from scratch -- from an empty machine to a fully configured wallet daemon with session credentials.
+
+> AI agents must NEVER request the master password. Use only your session token.
+
+## Prerequisites
+
+- **Node.js 22 LTS** or later (`node --version`)
+- **npm** package manager (bundled with Node.js)
+
+## Setup Flow
+
+Follow these steps in order. Steps 3 and 4 require human input for the master password.
+
+### Step 1: Install CLI
+
+Check if WAIaaS CLI is already installed:
+
+```bash
+which waiaas
+```
+
+If not found, install globally:
+
+```bash
+npm install -g @waiaas/cli
+```
+
+Verify installation:
+
+```bash
+waiaas --version
+```
+
+### Step 2: Initialize Data Directory
+
+Create the WAIaaS data directory and default configuration:
+
+```bash
+waiaas init
+```
+
+This creates `~/.waiaas/` with `config.toml` and required subdirectories. Safe to run multiple times -- skips if already initialized.
+
+### Step 3: Start Daemon
+
+```bash
+waiaas start
+```
+
+**IMPORTANT: On first run, the daemon prompts for a master password.**
+
+- The master password encrypts all private keys at rest
+- This is a human-only secret -- wait for the user to type it
+- Do NOT attempt to provide, generate, or capture the master password
+- The daemon starts after the password is set
+
+Verify the daemon is running:
+
+```bash
+curl -s http://localhost:3100/health
+```
+
+Expected: `{"status":"ok", ...}`
+
+### Step 4: Create Wallet and Session
+
+```bash
+waiaas quickset
+```
+
+**IMPORTANT: This command prompts for the master password.**
+
+- Wait for the user to enter the master password
+- Do NOT attempt to provide or capture it
+
+The command outputs:
+1. Wallet IDs and public keys (Solana + EVM)
+2. **Session tokens** (`wai_sess_...`) -- capture these
+3. MCP configuration JSON
+
+### Step 5: Configure Environment
+
+Set environment variables with the session token from Step 4:
+
+```bash
+export WAIAAS_BASE_URL=http://localhost:3100
+export WAIAAS_SESSION_TOKEN=<session-token-from-step-4>
+```
+
+Replace `<session-token-from-step-4>` with the actual `wai_sess_...` token printed by `quickset`.
+
+### Step 6: Verify Connection
+
+Call the self-discovery endpoint to confirm everything works:
+
+```bash
+curl -s http://localhost:3100/v1/connect-info \
+  -H "Authorization: Bearer $WAIAAS_SESSION_TOKEN"
+```
+
+This returns:
+- Accessible wallets and their networks
+- Active policies
+- Available capabilities
+- AI-ready usage prompt
+
+### Step 7: Install Skill Files
+
+Install WAIaaS skill files for your AI agent platform:
+
+**Agent Skills standard (Codex, Gemini CLI, Goose, Amp, Roo Code, Cursor, GitHub Copilot):**
+
+```bash
+npx @waiaas/skills agent-skills
+```
+
+**Claude Code:**
+
+```bash
+npx @waiaas/skills claude-code
+```
+
+**OpenClaw:**
+
+```bash
+npx @waiaas/skills openclaw
+```
+
+**Generic (copy to current directory):**
+
+```bash
+npx @waiaas/skills add all
+```
+
+## What's Next
+
+After setup is complete, refer to these skills for specific operations:
+
+| Skill | Description |
+|-------|-------------|
+| `quickstart` | Check balance, send first transfer |
+| `wallet` | Wallet CRUD, asset queries, session management |
+| `transactions` | All 5 transaction types with full parameters |
+| `policies` | 12 policy types for spending limits and access controls |
+| `admin` | Daemon status, kill switch, notifications, settings |
+| `actions` | DeFi actions (Jupiter Swap, 0x DEX, LI.FI Bridge, Lido/Jito Staking) |
+| `x402` | HTTP 402 auto-payment protocol |
+
+## Troubleshooting
+
+### `waiaas: command not found`
+
+npm global bin directory may not be in PATH:
+
+```bash
+npm config get prefix
+# Add <prefix>/bin to your PATH
+```
+
+### Daemon fails to start
+
+Check if port 3100 is already in use:
+
+```bash
+lsof -i :3100
+```
+
+Or change the port in `~/.waiaas/config.toml`:
+
+```toml
+[server]
+port = 3200
+```
+
+### `quickset` fails with authentication error
+
+The master password may be incorrect. The daemon validates the password on startup since v2.4. Restart the daemon with the correct password:
+
+```bash
+waiaas stop
+waiaas start
+```


### PR DESCRIPTION
## Summary
- Add `setup.skill.md` — zero-state daemon setup skill for AI agents (CLI install → init → start → quickset → env config → skill install)
- Register setup skill in `SKILL_REGISTRY` (7 → 8 skills)
- Lighten 3 guide docs (`agent-skills`, `claude-code`, `openclaw`) by delegating common prerequisites to setup skill
- Add "Agent Self-Setup" section to README as entry point for agents

## Test plan
- [ ] `pnpm turbo run build --filter=@waiaas/skills` succeeds with 8 skills synced
- [ ] Guide docs reference setup skill correctly
- [ ] README "Agent Self-Setup" section contains correct commands
- [ ] `setup.skill.md` and `packages/skills/skills/setup.skill.md` are in sync after build

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)