### PR TITLE
fix: deterministic Docker build for native addons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # =============================================================================
 # WAIaaS Docker Image -- Multi-stage build
-# Stage 1 (builder): Install deps + build all packages via turbo
-# Stage 2 (runner):  Production-only deps + dist artifacts + non-root user
+# Stage 1 (builder):   Install deps + build all packages via turbo
+# Stage 2 (prod-deps): Production-only deps with build tools for native addons
+# Stage 3 (runner):    Slim image with pre-built deps + dist artifacts
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -44,7 +45,25 @@ RUN pnpm turbo build --filter=@waiaas/daemon... --filter=@waiaas/cli... --filter
 
 
 # ---------------------------------------------------------------------------
-# Stage 2: runner
+# Stage 2: prod-deps
+# Build tools (python3/make/g++) are inherited from builder, so native addon
+# compilation always succeeds even when prebuilt binary download fails.
+# ---------------------------------------------------------------------------
+FROM builder AS prod-deps
+
+WORKDIR /prod
+
+RUN cp /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/turbo.json ./ && \
+    for dir in core daemon admin adapters/solana adapters/evm cli sdk mcp push-relay actions; do \
+      mkdir -p "packages/$dir" && \
+      cp "/app/packages/$dir/package.json" "packages/$dir/"; \
+    done
+
+RUN pnpm install --frozen-lockfile --prod
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: runner
 # ---------------------------------------------------------------------------
 FROM node:22-slim AS runner
 
@@ -69,29 +88,12 @@ RUN apt-get update \
 # Non-root user (UID 1001)
 RUN groupadd -g 1001 waiaas && useradd -u 1001 -g waiaas -m -s /bin/sh waiaas
 
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
-
 WORKDIR /app
 
-# 1) Copy workspace config for pnpm install --prod
-COPY --from=builder /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/turbo.json ./
+# 1) Copy production dependencies (pre-compiled native addons from prod-deps stage)
+COPY --from=prod-deps /prod/ ./
 
-# 2) Copy each package's package.json
-COPY --from=builder /app/packages/core/package.json packages/core/package.json
-COPY --from=builder /app/packages/daemon/package.json packages/daemon/package.json
-COPY --from=builder /app/packages/admin/package.json packages/admin/package.json
-COPY --from=builder /app/packages/adapters/solana/package.json packages/adapters/solana/package.json
-COPY --from=builder /app/packages/adapters/evm/package.json packages/adapters/evm/package.json
-COPY --from=builder /app/packages/cli/package.json packages/cli/package.json
-COPY --from=builder /app/packages/sdk/package.json packages/sdk/package.json
-COPY --from=builder /app/packages/mcp/package.json packages/mcp/package.json
-COPY --from=builder /app/packages/push-relay/package.json packages/push-relay/package.json
-COPY --from=builder /app/packages/actions/package.json packages/actions/package.json
-
-# 3) Install production dependencies only
-RUN pnpm install --frozen-lockfile --prod
-
-# 4) Copy build artifacts (dist directories)
+# 2) Copy build artifacts (dist directories)
 COPY --from=builder /app/packages/core/dist packages/core/dist
 COPY --from=builder /app/packages/daemon/dist packages/daemon/dist
 COPY --from=builder /app/packages/daemon/public packages/daemon/public
@@ -103,14 +105,14 @@ COPY --from=builder /app/packages/sdk/dist packages/sdk/dist
 COPY --from=builder /app/packages/mcp/dist packages/mcp/dist
 COPY --from=builder /app/packages/actions/dist packages/actions/dist
 
-# 5) Copy and prepare entrypoint
+# 3) Copy and prepare entrypoint
 COPY docker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
-# 6) Create data directory with correct ownership
+# 4) Create data directory with correct ownership
 RUN mkdir -p /data && chown -R waiaas:waiaas /data /app
 
-# 7) Environment configuration
+# 5) Environment configuration
 ENV NODE_ENV=production
 ENV WAIAAS_DATA_DIR=/data
 ENV WAIAAS_DAEMON_HOSTNAME=0.0.0.0

--- a/packages/push-relay/Dockerfile
+++ b/packages/push-relay/Dockerfile
@@ -1,7 +1,8 @@
 # =============================================================================
 # WAIaaS Push Relay Docker Image -- Multi-stage build
-# Stage 1 (builder): Install deps + build core + push-relay via turbo
-# Stage 2 (runner):  Production-only deps + dist artifacts + non-root user
+# Stage 1 (builder):   Install deps + build core + push-relay via turbo
+# Stage 2 (prod-deps): Production-only deps with build tools for native addons
+# Stage 3 (runner):    Slim image with pre-built deps + dist artifacts
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -34,8 +35,27 @@ COPY . .
 # 5) Build push-relay and its dependencies
 RUN pnpm turbo build --filter=@waiaas/push-relay...
 
+
 # ---------------------------------------------------------------------------
-# Stage 2: runner
+# Stage 2: prod-deps
+# Build tools (python3/make/g++) are inherited from builder, so native addon
+# compilation always succeeds even when prebuilt binary download fails.
+# ---------------------------------------------------------------------------
+FROM builder AS prod-deps
+
+WORKDIR /prod
+
+RUN cp /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/turbo.json ./ && \
+    for dir in core push-relay; do \
+      mkdir -p "packages/$dir" && \
+      cp "/app/packages/$dir/package.json" "packages/$dir/"; \
+    done
+
+RUN pnpm install --frozen-lockfile --prod
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: runner
 # ---------------------------------------------------------------------------
 FROM node:22-slim AS runner
 
@@ -56,31 +76,22 @@ RUN apt-get update \
 # Non-root user (UID 1001)
 RUN groupadd -g 1001 waiaas && useradd -u 1001 -g waiaas -m -s /bin/sh waiaas
 
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
-
 WORKDIR /app
 
-# 1) Copy workspace config for pnpm install --prod
-COPY --from=builder /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/turbo.json ./
+# 1) Copy production dependencies (pre-compiled native addons from prod-deps stage)
+COPY --from=prod-deps /prod/ ./
 
-# 2) Copy each package's package.json
-COPY --from=builder /app/packages/core/package.json packages/core/package.json
-COPY --from=builder /app/packages/push-relay/package.json packages/push-relay/package.json
-
-# 3) Install production dependencies only
-RUN pnpm install --frozen-lockfile --prod
-
-# 4) Copy build artifacts (dist directories)
+# 2) Copy build artifacts (dist directories)
 COPY --from=builder /app/packages/core/dist packages/core/dist
 COPY --from=builder /app/packages/push-relay/dist packages/push-relay/dist
 
-# 5) Copy example config
+# 3) Copy example config
 COPY --from=builder /app/packages/push-relay/config.example.toml /app/config.example.toml
 
-# 6) Create data directory with correct ownership
+# 4) Create data directory with correct ownership
 RUN mkdir -p /data && chown -R waiaas:waiaas /data /app
 
-# 7) Environment configuration
+# 5) Environment configuration
 ENV NODE_ENV=production
 ENV RELAY_CONFIG=/data/config.toml
 ENV RELAY_DB=/data/relay.db


### PR DESCRIPTION
## Summary
- Docker `v2.8.0` release build failed because `better-sqlite3` prebuilt binary download got "socket hang up", and the runner stage (`node:22-slim`) lacks Python for the `node-gyp` fallback
- Add an intermediate `prod-deps` stage inheriting build tools (python3/make/g++) from builder, so native addon compilation always succeeds regardless of network conditions
- Apply the same fix to both `Dockerfile` (daemon) and `packages/push-relay/Dockerfile`

## Root Cause
The previous 2-stage build ran `pnpm install --frozen-lockfile --prod` in the slim runner stage. This worked only when `prebuild-install` successfully downloaded prebuilt binaries. On transient GitHub CDN failures, it fell back to `node-gyp` which requires Python — not present in `node:22-slim`.

## Test plan
- [ ] CI release workflow Docker build step passes
- [ ] `docker build -t waiaas-daemon:test .` succeeds locally
- [ ] `docker build -t waiaas-push-relay:test packages/push-relay/` succeeds locally
- [ ] Container starts and `/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)