### PR TITLE
fix: use workflow_run trigger for E2E smoke tests (#284)

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,12 +1,13 @@
 name: E2E Smoke Tests
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Package version to test (e.g. 3.0.0-rc.1). Leave empty to use release tag.'
+        description: 'Package version to test (e.g. 3.0.0-rc.1). Leave empty to auto-detect latest release.'
         required: false
         default: ''
         type: string
@@ -19,6 +20,10 @@ jobs:
   e2e-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only run after successful Release workflow (skip failures/cancellations)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,15 +33,20 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
-          elif [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            # Strip 'v' prefix if present
-            VERSION="${VERSION#v}"
           else
-            VERSION="latest"
+            # Get latest release tag from GitHub API
+            TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
+            if [ -z "$TAG" ]; then
+              echo "::error::Could not determine release version"
+              exit 1
+            fi
+            # Strip 'v' prefix if present
+            VERSION="${TAG#v}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Testing version: $VERSION"
@@ -45,7 +55,27 @@ jobs:
         run: pnpm turbo run build --filter=@waiaas/e2e-tests
 
       - name: Install daemon globally
-        run: npm install -g @waiaas/daemon@${{ steps.version.outputs.version }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Retry with backoff — npm registry propagation may take a few minutes
+          MAX_ATTEMPTS=5
+          ATTEMPT=1
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: npm install -g @waiaas/daemon@$VERSION"
+            if npm install -g "@waiaas/daemon@$VERSION" 2>&1; then
+              echo "Successfully installed @waiaas/daemon@$VERSION"
+              exit 0
+            fi
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              WAIT=$((ATTEMPT * 30))
+              echo "Install failed, retrying in ${WAIT}s..."
+              sleep $WAIT
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+          echo "::error::Failed to install @waiaas/daemon@$VERSION after $MAX_ATTEMPTS attempts"
+          exit 1
 
       - name: Run offchain E2E tests
         run: pnpm --filter @waiaas/e2e-tests test:offchain

--- a/internal/objectives/issues/284-e2e-smoke-race-condition.md
+++ b/internal/objectives/issues/284-e2e-smoke-race-condition.md
@@ -1,0 +1,49 @@
+# #284 E2E Smoke 워크플로우가 npm publish 전에 실행되어 실패
+
+- **유형:** BUG
+- **심각도:** HIGH
+- **마일스톤:** v31.7
+- **상태:** FIXED
+- **수정일:** 2026-03-09
+- **발견일:** 2026-03-09
+
+## 증상
+
+`e2e-smoke.yml` 워크플로우가 `on: release: [published]` 이벤트로 트리거되어 `release.yml`과 동시에 시작됨. `release.yml`의 `deploy` job(수동 승인 게이트 포함)이 npm publish를 완료하기 전에 `npm install -g @waiaas/daemon@2.10.0-rc.18`이 실행되어 `ETARGET` 에러로 실패.
+
+## 원인
+
+`release` 이벤트 발생 시 두 워크플로우가 동시에 트리거됨:
+1. `release.yml` — test → platform → deploy(수동 승인) → npm publish
+2. `e2e-smoke.yml` — npm install (아직 publish 안 됨) → 실패
+
+## 수정 방안
+
+`e2e-smoke.yml`의 트리거를 `on: release` → `on: workflow_run`으로 변경하여 `release.yml` 완료 후에만 실행되도록 함:
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+```
+
+- `release.yml`의 deploy job에 `environment: production` 수동 승인 게이트가 있으므로, 승인하지 않으면 워크플로우가 미종료 → E2E 미트리거
+- 승인 → npm publish 완료 → Release 워크플로우 종료 → E2E 트리거 (정상 순서)
+- npm propagation 지연 대비 retry 로직 추가
+
+## 실패 로그
+
+```
+npm error code ETARGET
+npm error notarget No matching version found for @waiaas/daemon@2.10.0-rc.18.
+```
+
+- Run: https://github.com/minhoyoo-iotrust/WAIaaS/actions/runs/22847805611
+
+## 테스트 항목
+
+- [ ] `release.yml` 완료 전에 `e2e-smoke.yml`이 트리거되지 않음 확인
+- [ ] `release.yml` deploy job 미승인 시 E2E 미트리거 확인
+- [ ] `release.yml` deploy 완료 후 E2E 정상 트리거 + npm install 성공 확인
+- [ ] `workflow_dispatch`로 수동 실행 시 버전 지정 정상 동작 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -298,6 +298,7 @@
 | 281 | BUG | HIGH | HyperEVM incoming.wss_url 설정 키 미등록 — IncomingTxMonitor 구독 실패 | — | FIXED | 2026-03-09 |
 | 282 | ENHANCEMENT | HIGH | 네트워크 설정 키 완전성 자동 검증 테스트 — NETWORK_TYPES SSoT 기반 동적 검증 | v31.7 | RESOLVED | 2026-03-09 |
 | 283 | ENHANCEMENT | LOW | README 테스트 배지 자동 업데이트 — 하드코딩 제거, Gist + shields.io endpoint 동적 배지 | v31.7 | RESOLVED | 2026-03-09 |
+| 284 | BUG | HIGH | E2E Smoke 워크플로우가 npm publish 전에 실행되어 실패 — workflow_run 전환 필요 | v31.7 | FIXED | 2026-03-09 |
 
 ## Type Legend
 
@@ -309,9 +310,9 @@
 
 ## Summary
 
-- **OPEN:** 0
+- **OPEN:** 1
 - **FIXED:** 281
 - **RESOLVED:** 4
 - **VERIFIED:** 0
 - **WONTFIX:** 1
-- **Total:** 286
+- **Total:** 287


### PR DESCRIPTION
## Summary
- Switch `e2e-smoke.yml` trigger from `on: release: [published]` to `on: workflow_run` to ensure E2E tests only run **after** the Release workflow completes and npm packages are published
- Add retry with exponential backoff (5 attempts, 30s/60s/90s/120s) for `npm install` to handle registry propagation delays
- Skip execution when Release workflow fails or is cancelled via `if: workflow_run.conclusion == 'success'`

Fixes #284

## Test plan
- [ ] `release.yml` 완료 전에 `e2e-smoke.yml`이 트리거되지 않음 확인
- [ ] `release.yml` deploy job 미승인 시 E2E 미트리거 확인
- [ ] `release.yml` deploy 완료 후 E2E 정상 트리거 + npm install 성공 확인
- [ ] `workflow_dispatch`로 수동 실행 시 버전 지정 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)