### PR TITLE
Milestone v31.8: E2E global install mode support

### DIFF
--- a/internal/objectives/issues/285-e2e-daemon-global-install-mode.md
+++ b/internal/objectives/issues/285-e2e-daemon-global-install-mode.md
@@ -1,0 +1,72 @@
+# 285 — E2E DaemonManager가 E2E_DAEMON_INSTALL_MODE=global 미지원
+
+- **유형:** BUG
+- **심각도:** HIGH
+- **마일스톤:** v31.8
+- **발견일:** 2026-03-09
+- **수정일:** 2026-03-09
+- **발견 경로:** GitHub Actions run #22850819564
+
+## 증상
+
+E2E Smoke 워크플로우(`e2e-smoke.yml`)에서 오프체인 테스트 8개 suite가 전부 실패. 모든 테스트가 `beforeAll`에서 데몬 시작 실패로 skip 처리됨.
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+  '/home/runner/work/WAIaaS/WAIaaS/packages/cli/dist/index.js'
+  imported from /home/runner/work/WAIaaS/WAIaaS/packages/cli/bin/waiaas
+```
+
+Push Relay 테스트도 동일 패턴:
+```
+PushRelayManager: bin not found at
+  /home/runner/work/WAIaaS/WAIaaS/packages/push-relay/dist/bin.js
+```
+
+## 원인
+
+`DaemonManager.resolveMonorepoCli()`가 항상 모노레포 내부 경로(`packages/cli/bin/waiaas`)를 반환함. CI 워크플로우에서 `E2E_DAEMON_INSTALL_MODE=global` 환경변수를 설정하지만, `daemon-lifecycle.ts` 코드에서 이 환경변수를 읽는 로직이 없음.
+
+CI 실행 흐름:
+1. `pnpm turbo run build --filter=@waiaas/e2e-tests` — e2e-tests만 빌드 (cli 빌드 안 함)
+2. `npm install -g @waiaas/daemon@$VERSION` — npm에서 글로벌 설치 (성공)
+3. 테스트 실행 → `resolveMonorepoCli()` → `packages/cli/dist/index.js` 찾음 → 없음 → 실패
+
+즉, 글로벌 설치된 `waiaas` 바이너리를 사용해야 하는데, 항상 빌드 안 된 모노레포 경로를 참조하는 것이 근본 원인.
+
+`PushRelayManager`도 동일 — 글로벌/외부 설치 경로를 지원하지 않음.
+
+## 수정 방안
+
+`DaemonManager`가 `E2E_DAEMON_INSTALL_MODE` 환경변수를 읽어 CLI 경로를 결정하도록 수정:
+
+1. **`daemon-lifecycle.ts`**: `resolveMonorepoCli()` 전에 `E2E_DAEMON_INSTALL_MODE=global`이면 `which waiaas` 결과를 사용
+2. **`push-relay-lifecycle.ts`**: 동일하게 `E2E_PUSH_RELAY_INSTALL_MODE=global` 또는 `PUSH_RELAY_BIN_PATH` 환경변수로 글로벌 설치 경로 지원
+
+```typescript
+// daemon-lifecycle.ts 수정 예시
+private resolveCliPath(explicitPath?: string): string {
+  if (explicitPath) return explicitPath;
+  if (process.env['WAIAAS_CLI_PATH']) return process.env['WAIAAS_CLI_PATH'];
+  if (process.env['E2E_DAEMON_INSTALL_MODE'] === 'global') {
+    // 글로벌 설치된 waiaas 바이너리 사용
+    const globalBin = execSync('which waiaas', { encoding: 'utf-8' }).trim();
+    if (globalBin) return globalBin;
+  }
+  return this.resolveMonorepoCli();
+}
+```
+
+## 영향 범위
+
+- `packages/e2e-tests/src/helpers/daemon-lifecycle.ts` — CLI 경로 해석 로직
+- `packages/e2e-tests/src/helpers/push-relay-lifecycle.ts` — Push Relay 바이너리 경로 해석 로직
+- `.github/workflows/e2e-smoke.yml` — 워크플로우 변경 불필요 (코드 수정만으로 해결)
+
+## 테스트 항목
+
+1. `E2E_DAEMON_INSTALL_MODE=global` + `waiaas` 글로벌 설치 시 데몬 정상 시작 확인
+2. 환경변수 미설정 시 기존 모노레포 경로 폴백 동작 확인
+3. `WAIAAS_CLI_PATH` 명시적 경로 우선순위 확인
+4. Push Relay도 동일하게 글로벌 모드 동작 확인
+5. CI에서 E2E Smoke 워크플로우 정상 통과 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -299,6 +299,7 @@
 | 282 | ENHANCEMENT | HIGH | 네트워크 설정 키 완전성 자동 검증 테스트 — NETWORK_TYPES SSoT 기반 동적 검증 | v31.7 | RESOLVED | 2026-03-09 |
 | 283 | ENHANCEMENT | LOW | README 테스트 배지 자동 업데이트 — 하드코딩 제거, Gist + shields.io endpoint 동적 배지 | v31.7 | RESOLVED | 2026-03-09 |
 | 284 | BUG | HIGH | E2E Smoke 워크플로우가 npm publish 전에 실행되어 실패 — workflow_run 전환 필요 | v31.7 | FIXED | 2026-03-09 |
+| 285 | BUG | HIGH | E2E DaemonManager가 E2E_DAEMON_INSTALL_MODE=global 미지원 — CI에서 전 테스트 skip | v31.8 | FIXED | 2026-03-09 |
 
 ## Type Legend
 
@@ -310,9 +311,9 @@
 
 ## Summary
 
-- **OPEN:** 1
-- **FIXED:** 281
+- **OPEN:** 0
+- **FIXED:** 283
 - **RESOLVED:** 4
 - **VERIFIED:** 0
 - **WONTFIX:** 1
-- **Total:** 287
+- **Total:** 288

--- a/packages/e2e-tests/src/helpers/daemon-lifecycle.ts
+++ b/packages/e2e-tests/src/helpers/daemon-lifecycle.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:net';
-import { fork, type ChildProcess } from 'node:child_process';
+import { fork, spawn, execSync, type ChildProcess } from 'node:child_process';
 
 export interface DaemonInstance {
   dataDir: string;
@@ -64,30 +64,38 @@ path = "data/waiaas.db"
 `;
     writeFileSync(join(dataDir, 'config.toml'), config, { mode: 0o644 });
 
-    // 3. Resolve CLI path
+    // 3. Resolve CLI path and spawn mode
+    const useGlobal = process.env['E2E_DAEMON_INSTALL_MODE'] === 'global';
     const cliPath = opts?.cliPath
       ?? process.env['WAIAAS_CLI_PATH']
-      ?? this.resolveMonorepoCli();
+      ?? (useGlobal ? this.resolveGlobalCli() : this.resolveMonorepoCli());
 
-    if (!existsSync(cliPath)) {
+    if (!useGlobal && !existsSync(cliPath)) {
       throw new Error(
         `DaemonManager: CLI entrypoint not found at ${cliPath}. ` +
         `Build with 'pnpm turbo run build --filter=@waiaas/cli' or set WAIAAS_CLI_PATH.`,
       );
     }
 
-    // 4. Fork the CLI process
+    // 4. Spawn the CLI process
     this.stdout = [];
     this.stderr = [];
 
-    const child = fork(cliPath, ['start', '--data-dir', dataDir], {
-      env: {
-        ...process.env,
-        WAIAAS_MASTER_PASSWORD: masterPassword,
-      },
-      stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
-      silent: true,
-    });
+    const childEnv = {
+      ...process.env,
+      WAIAAS_MASTER_PASSWORD: masterPassword,
+    };
+
+    const child: ChildProcess = useGlobal
+      ? spawn(cliPath, ['start', '--data-dir', dataDir], {
+          env: childEnv,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+      : fork(cliPath, ['start', '--data-dir', dataDir], {
+          env: childEnv,
+          stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+          silent: true,
+        });
 
     // Collect output for debugging
     child.stdout?.on('data', (chunk: Buffer) => {
@@ -203,6 +211,18 @@ path = "data/waiaas.db"
         }
       });
     });
+  }
+
+  /** Resolve globally installed waiaas CLI binary. */
+  private resolveGlobalCli(): string {
+    try {
+      return execSync('which waiaas', { encoding: 'utf-8' }).trim();
+    } catch {
+      throw new Error(
+        'DaemonManager: E2E_DAEMON_INSTALL_MODE=global but `waiaas` not found in PATH. ' +
+        'Install with `npm install -g @waiaas/daemon`.',
+      );
+    }
   }
 
   /** Resolve CLI bin path within monorepo. */

--- a/packages/e2e-tests/src/helpers/push-relay-lifecycle.ts
+++ b/packages/e2e-tests/src/helpers/push-relay-lifecycle.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:net';
-import { fork, type ChildProcess } from 'node:child_process';
+import { fork, spawn, execSync, type ChildProcess } from 'node:child_process';
 
 export interface PushRelayInstance {
   dataDir: string;
@@ -65,30 +65,38 @@ api_key = "e2e-test-api-key"
 `;
     writeFileSync(join(dataDir, 'config.toml'), config, { mode: 0o644 });
 
-    // 3. Resolve bin path
+    // 3. Resolve bin path and spawn mode
+    const useGlobal = process.env['E2E_PUSH_RELAY_INSTALL_MODE'] === 'global';
     const binPath = opts?.binPath
       ?? process.env['PUSH_RELAY_BIN_PATH']
-      ?? this.resolveMonorepoBin();
+      ?? (useGlobal ? this.resolveGlobalBin() : this.resolveMonorepoBin());
 
-    if (!existsSync(binPath)) {
+    if (!useGlobal && !existsSync(binPath)) {
       throw new Error(
         `PushRelayManager: bin not found at ${binPath}. ` +
         `Build with 'pnpm turbo run build --filter=@waiaas/push-relay' or set PUSH_RELAY_BIN_PATH.`,
       );
     }
 
-    // 4. Fork the process
+    // 4. Spawn the process
     this.stdout = [];
     this.stderr = [];
 
-    const child = fork(binPath, [], {
-      env: {
-        ...process.env,
-        RELAY_CONFIG: join(dataDir, 'config.toml'),
-      },
-      stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
-      silent: true,
-    });
+    const childEnv = {
+      ...process.env,
+      RELAY_CONFIG: join(dataDir, 'config.toml'),
+    };
+
+    const child: ChildProcess = useGlobal
+      ? spawn(binPath, [], {
+          env: childEnv,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+      : fork(binPath, [], {
+          env: childEnv,
+          stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+          silent: true,
+        });
 
     child.stdout?.on('data', (chunk: Buffer) => {
       this.stdout.push(chunk.toString());
@@ -187,6 +195,18 @@ api_key = "e2e-test-api-key"
         }
       });
     });
+  }
+
+  /** Resolve globally installed push-relay binary. */
+  private resolveGlobalBin(): string {
+    try {
+      return execSync('which waiaas-push-relay', { encoding: 'utf-8' }).trim();
+    } catch {
+      throw new Error(
+        'PushRelayManager: E2E_PUSH_RELAY_INSTALL_MODE=global but `waiaas-push-relay` not found in PATH. ' +
+        'Install with `npm install -g @waiaas/push-relay`.',
+      );
+    }
   }
 
   /** Resolve push-relay bin path within monorepo. */


### PR DESCRIPTION
## Summary
- Fix DaemonManager to support `E2E_DAEMON_INSTALL_MODE=global` env var, resolving CLI path via `which waiaas` and using `spawn()` instead of `fork()` for globally installed binaries
- Apply same pattern to PushRelayManager with `E2E_PUSH_RELAY_INSTALL_MODE=global`
- Update issue tracker (#285 FIXED)

## Test plan
- [ ] CI E2E smoke workflow passes with `E2E_DAEMON_INSTALL_MODE=global`
- [ ] Local monorepo mode still works without env var (fallback to `resolveMonorepoCli`)
- [ ] `WAIAAS_CLI_PATH` explicit path takes priority over both modes

Fixes #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)