### PR TITLE
fix: add og:image:type and alt meta tags for Twitter/X card preview

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -14,14 +14,17 @@
   <meta property="og:site_name" content="WAIaaS">
 
   <meta property="og:image" content="https://waiaas.ai/og-image.png">
+  <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="WAIaaS — Self-hosted Wallet-as-a-Service for AI Agents">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="WAIaaS — Wallet-as-a-Service for AI Agents">
   <meta name="twitter:description" content="Self-hosted daemon for AI agents to securely manage crypto wallets. Multi-chain EVM + Solana, 13+ DeFi protocols, MCP built-in.">
   <meta name="twitter:image" content="https://waiaas.ai/og-image.png">
+  <meta name="twitter:image:alt" content="WAIaaS — Self-hosted Wallet-as-a-Service for AI Agents">
 
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- Add `og:image:type` meta tag — Twitter/X requires this to render preview images
- Add `og:image:alt` and `twitter:image:alt` for accessibility

## Test plan
- [ ] Share https://waiaas.ai on X/Twitter and verify preview card appears
- [ ] Validate via https://cards-dev.twitter.com/validator (or post to X)
- [ ] Verify Telegram preview after cache purge (@WebPageBot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)