### PR TITLE
fix: resolve issues #391-394 — DeFi positions, token registry, DCent Swap

### DIFF
--- a/internal/objectives/issues/391-polygon-amoy-builtin-tokens-invalid.md
+++ b/internal/objectives/issues/391-polygon-amoy-builtin-tokens-invalid.md
@@ -1,0 +1,66 @@
+# 391 — Polygon Amoy 빌트인 토큰 3개 컨트랙트 미존재로 매 요청마다 에러 로그 발생
+
+- **유형:** BUG
+- **심각도:** MEDIUM
+- **상태:** FIXED
+- **마일스톤:** (미정)
+- **발견일:** 2026-03-19
+
+## 현상
+
+`GET /v1/wallet/balance` 및 `GET /v1/wallet/assets` 호출 시 polygon-amoy 네트워크에서 다음 3개 토큰의 `balanceOf` 호출이 매번 실패한다:
+
+| 토큰 | 주소 | 오류 |
+|------|------|------|
+| AAVE | `0x1558c6FadDe1bEaf0f6628BDd1DFf3461185eA24` | `balanceOf returned no data ("0x")` |
+| DAI | `0xc8c0Cf9436F4862a8F60Ce680Ca5a9f0f99b5ded` | `balanceOf returned no data ("0x")` |
+| USDT | `0x1fdE0eCc619726f4cD597887C9F3b4c8740e19e2` | `balanceOf returned no data ("0x")` |
+
+viem 에러 메시지: "The address is not a contract" — 해당 주소에 배포된 컨트랙트가 없음.
+
+## 영향
+
+- **모든 지갑**의 polygon-amoy 잔액/자산 조회 시 발생 (지갑당 3개 토큰 × 2단계 시도 = 6회 에러 로그)
+- multicall 실패 → 개별 readContract fallback → 또 실패 → skip — 불필요한 2단계 fallback으로 응답 시간 증가
+- 데몬 로그가 에러로 오염되어 실제 문제 식별이 어려움
+
+## 원인
+
+`packages/daemon/src/infrastructure/token-registry/builtin-tokens.ts`의 `polygon-amoy` 항목에 등록된 토큰 주소가 Aave TestnetMintableERC20 기반이었으나, Polygon Amoy 테스트넷 리셋/재배포로 해당 컨트랙트가 더 이상 존재하지 않음.
+
+## 수정 방안
+
+### A. 즉시 수정 — 미존재 토큰 제거 (권장)
+
+`builtin-tokens.ts`에서 polygon-amoy의 AAVE, DAI, USDT 3개 항목 제거. 7토큰 → 4토큰(USDC, WETH, LINK, WPOL).
+
+### B. 방어적 개선 — 컨트랙트 존재 확인 캐싱
+
+EVM adapter에서 `balanceOf` 실패 시 해당 토큰 주소를 "invalid contract" 캐시에 추가하여, 이후 조회에서 반복 시도하지 않도록 함. 이는 사용자 등록 토큰이나 향후 다른 테스트넷 리셋에도 대응 가능.
+
+### C. 전체 테스트넷 토큰 검증
+
+다른 테스트넷(ethereum-sepolia, arbitrum-sepolia, optimism-sepolia, base-sepolia) 빌트인 토큰도 현재 유효한지 확인. 현재 데몬 로그에는 polygon-amoy만 발생하고 있으나, 테스트넷 특성상 주기적 검증 필요.
+
+### D. 영향받는 네트워크/토큰 전체 분석
+
+| 네트워크 | 토큰 수 | 확인된 상태 |
+|----------|---------|-------------|
+| ethereum-sepolia | 11 | 로그 에러 없음 — 정상 추정 |
+| polygon-amoy | 7 → **3개 미존재** | AAVE, DAI, USDT 컨트랙트 없음 |
+| arbitrum-sepolia | 4 | 로그 에러 없음 — 정상 추정 |
+| optimism-sepolia | 3 | 로그 에러 없음 — 정상 추정 |
+| base-sepolia | 7 | 로그 에러 없음 — 정상 추정 |
+| 메인넷 5개 | 3~6 | 메인넷은 리셋 없으므로 안정 |
+
+## 수정 대상 파일
+
+- `packages/daemon/src/infrastructure/token-registry/builtin-tokens.ts` — polygon-amoy 항목 수정
+- (선택) `packages/adapters/evm/src/adapter.ts` — invalid contract 캐싱 로직 추가
+
+## 테스트 항목
+
+1. **유닛 테스트**: `getBuiltinTokens('polygon-amoy')` 반환 토큰 수 검증 (7→4)
+2. **유닛 테스트**: EVM adapter에서 `balanceOf` 실패 시 에러 로그 확인 및 skip 동작 기존 테스트 유지
+3. **통합 테스트**: polygon-amoy 지갑의 `/v1/wallet/assets` 호출 시 에러 로그 없이 정상 응답 확인
+4. (B안 적용 시) **유닛 테스트**: invalid contract 캐시에 추가된 토큰은 재시도하지 않음 검증

--- a/internal/objectives/issues/392-position-tracker-walletid-uuid-not-address.md
+++ b/internal/objectives/issues/392-position-tracker-walletid-uuid-not-address.md
@@ -1,0 +1,135 @@
+# Issue #392: PositionTracker가 지갑 UUID를 온체인 주소로 사용하여 모든 DeFi 포지션 조회 실패
+
+- **유형:** BUG
+- **심각도:** CRITICAL
+- **상태:** FIXED
+- **발견 경로:** Admin 대시보드 DeFi 포지션 반복 미표시 조사 — #386, #380 수정 후에도 재발
+
+## 배경
+
+Admin 대시보드 DeFi Positions 섹션에서 "Include testnets" 활성화 후에도 Lido 스테이킹 포지션이 표시되지 않는다. 이 문제는 이전 이슈(#386 Holesky 주소 불일치, #380 RPC URL 누락) 수정 후에도 반복된다.
+
+반면 지갑 상세 → Assets 탭의 "Staking Positions"에는 정상 표시된다.
+
+## 원인 분석
+
+### 핵심 버그: walletId(UUID v7)를 온체인 주소로 사용
+
+`PositionQueryContext`에는 `walletId` 필드만 존재하며, 이는 DB의 `wallets.id` (UUID v7, 예: `01927f6e-3c4a-7f1b-...`)이다. **지갑의 블록체인 주소(`public_key` 컬럼, 예: `0x1234...abcd`)가 아니다.**
+
+모든 포지션 프로바이더가 이 UUID를 `balanceOf(address)` 등 온체인 RPC 호출의 주소 파라미터로 사용한다:
+
+```typescript
+// position-tracker.ts:155-157 — UUID를 walletId로 전달
+const wallets = this.sqlite
+  .prepare("SELECT id, chain, environment FROM wallets WHERE status = 'ACTIVE'")
+  .all(); // wallet.id = UUID v7
+
+// position-tracker.ts:179-184 — UUID가 ctx.walletId에 들어감
+const ctx: PositionQueryContext = {
+  walletId: wallet.id,  // ← UUID v7, NOT 블록체인 주소
+  chain, networks, environment, rpcUrls,
+};
+```
+
+### 영향받는 프로바이더 (전수 조사)
+
+| 프로바이더 | 파일 | 사용 위치 | 호출 내용 |
+|-----------|------|----------|----------|
+| **Lido Staking** | `lido-staking/index.ts` | L230, L255 | `encodeBalanceOfCalldata(walletId)` — stETH/wstETH 잔액 |
+| **Aave V3** | `aave-v3/index.ts` | L490, L502, L505 | `encodeGetUserAccountDataCalldata(walletId)`, `encodeBalanceOfCalldata(walletId)` — aToken/debtToken 잔액 |
+| **Pendle Yield** | `pendle/index.ts` | L349, L373 | `encodeBalanceOfCalldata(walletId)` — PT/YT 토큰 잔액 |
+| **Jito Staking** | `jito-staking/index.ts` | L176 | `getJitoSolBalance(walletId)` — JitoSOL 잔액 |
+| **Kamino Lending** | `kamino/index.ts` | L430 | `walletAddress: walletId` — obligation 조회 |
+| **Drift Perp** | `drift/index.ts` | L353 | `sdkWrapper.getPositions(walletId)` — 포지션 조회 |
+| **Hyperliquid Spot** | `hyperliquid/spot-provider.ts` | L369 | `marketData.getSpotBalances(walletId)` — 잔액 조회 |
+
+### 결과
+
+- `addressToHex(walletId)` → UUID의 첫 2글자(`01`)가 `0x` 접두사로 오인되어 잘림 → 잘못된 주소로 RPC 호출
+- EVM: `balanceOf(잘못된주소)` → 항상 0 반환 → 포지션 미생성
+- Solana: 유효하지 않은 base58 파싱 실패 → 에러 → 포지션 미생성
+- 모든 프로바이더에서 `defi_positions` 테이블에 아무 행도 삽입되지 않음
+
+### Assets 탭은 왜 작동하는가
+
+Assets 탭의 "Staking Positions"는 **다른 데이터 소스**를 사용한다:
+- `GET /v1/admin/wallets/{id}/staking` → `aggregateStakingBalance()` → **`transactions` 테이블 기반 집계** (온체인 조회 없음)
+- DeFi Positions 대시보드 → `GET /v1/admin/defi/positions` → **`defi_positions` 테이블 조회** (PositionTracker가 온체인 동기화한 데이터)
+
+## 수정 사항
+
+### 1. `PositionQueryContext`에 `walletAddress` 필드 추가
+
+```typescript
+// packages/core/src/interfaces/position-provider.types.ts
+export interface PositionQueryContext {
+  walletId: string;
+  walletAddress: string;  // ← 신규: 온체인 주소 (0x... 또는 base58)
+  chain: ChainType;
+  networks: readonly NetworkType[];
+  environment: EnvironmentType;
+  rpcUrls: Record<string, string>;
+}
+```
+
+### 2. PositionTracker에서 `public_key` 조회 후 전달
+
+```typescript
+// packages/daemon/src/services/defi/position-tracker.ts:155-157
+const wallets = this.sqlite
+  .prepare("SELECT id, public_key, chain, environment FROM wallets WHERE status = 'ACTIVE'")
+  .all() as Array<{ id: string; public_key: string; chain: string; environment: string }>;
+
+// :179-184
+const ctx: PositionQueryContext = {
+  walletId: wallet.id,
+  walletAddress: wallet.public_key,  // ← 블록체인 주소
+  chain, networks, environment, rpcUrls,
+};
+```
+
+### 3. 모든 포지션 프로바이더에서 `walletAddress` 사용
+
+각 프로바이더의 `getPositions()` 및 내부 메서드에서 `walletId` 대신 `ctx.walletAddress`를 온체인 호출에 사용:
+
+- **Lido**: `encodeBalanceOfCalldata(walletAddress)` (L230, L255)
+- **Aave V3**: `encodeGetUserAccountDataCalldata(walletAddress)` (L490), `encodeBalanceOfCalldata(walletAddress)` (L502, L505)
+- **Pendle**: `encodeBalanceOfCalldata(walletAddress)` (L349, L373)
+- **Jito**: `getJitoSolBalance(walletAddress)` (L176)
+- **Kamino**: `walletAddress: walletAddress` (L430)
+- **Drift**: `sdkWrapper.getPositions(walletAddress)` (L353)
+- **Hyperliquid Spot**: `marketData.getSpotBalances(walletAddress)` (L369)
+
+### 4. 테스트 헬퍼 업데이트
+
+```typescript
+// position-tracker.test.ts:44-49
+function insertTestWallet(sqlite: DatabaseType, walletId: string): void {
+  sqlite.prepare(
+    "INSERT INTO wallets (id, name, chain, environment, public_key, status, created_at, updated_at) VALUES (?, 'test', 'ethereum', 'testnet', ?, 'ACTIVE', 0, 0)"
+  ).run(walletId, '0xAbCdEf0123456789AbCdEf0123456789AbCdEf01'); // 유효한 주소 사용
+}
+```
+
+## 영향 범위
+
+- **전 프로바이더 영향**: 모든 IPositionProvider 구현체 (7개 프로바이더)
+- **DeFi 대시보드 전체 비작동**: defi_positions 테이블에 데이터 미적재 → 대시보드 빈 상태
+- **HealthFactorMonitor 비작동**: Aave 포지션이 없으므로 health factor 모니터링 무효화
+- **MarginMonitor 비작동**: Drift/Hyperliquid 포지션 미감지
+
+## 테스트 항목
+
+- [ ] `PositionQueryContext`에 `walletAddress` 필드 추가 확인 (타입 레벨)
+- [ ] PositionTracker가 `SELECT id, public_key` 쿼리 후 `walletAddress`에 `public_key` 전달 확인
+- [ ] Lido `getPositions()`이 `walletAddress`로 `balanceOf` 호출 확인 (단위 테스트)
+- [ ] Aave V3 `getPositions()`이 `walletAddress`로 `getUserAccountData`, `balanceOf` 호출 확인
+- [ ] Pendle `getPositions()`이 `walletAddress`로 PT/YT `balanceOf` 호출 확인
+- [ ] Jito `getPositions()`이 `walletAddress`로 JitoSOL 잔액 조회 확인
+- [ ] Kamino `getPositions()`이 `walletAddress`로 obligation 조회 확인
+- [ ] Drift `getPositions()`이 `walletAddress`로 포지션 조회 확인
+- [ ] Hyperliquid Spot `getPositions()`이 `walletAddress`로 잔액 조회 확인
+- [ ] 통합 테스트: PositionTracker → Lido Provider → defi_positions 테이블 행 삽입 확인
+- [ ] Admin 대시보드: "Include testnets" 토글 시 테스트넷 Lido 포지션 표시 확인
+- [ ] 기존 PositionTracker 유닛 테스트 전수 통과 확인

--- a/internal/objectives/issues/393-dcent-swap-native-eth-value-mismatch.md
+++ b/internal/objectives/issues/393-dcent-swap-native-eth-value-mismatch.md
@@ -1,0 +1,96 @@
+# 393 — DCent Swap 네이티브 ETH 스왑 시 txdata.value 불일치로 온체인 revert
+
+- **유형:** BUG
+- **심각도:** HIGH
+- **상태:** FIXED
+- **마일스톤:** (미정)
+- **발견일:** 2026-03-19
+
+## 현상
+
+`POST /v1/actions/dcent_swap/dex_swap` (또는 `?dryRun=true`)으로 네이티브 ETH → USDC 스왑 실행 시 DCent 라우터 컨트랙트(`0xAC4c6e212A361c968F1725b4d055b47E63F80b75`)에서 `execution reverted` 발생.
+
+dryRun 결과:
+- `success: true` (정책 통과, DCent API에서 txdata 수신 성공)
+- `simulation.success: false` (온체인 estimateGas에서 revert)
+
+## 원인
+
+DCent API `get_dex_swap_transaction_data` 응답의 `txdata.value` 값이 스왑 금액과 일치하지 않는다.
+
+### 실제 API 응답 (0.005 ETH 스왑 요청 시)
+
+| 필드 | 기대값 | 실제값 |
+|------|--------|--------|
+| `txdata.value` | `5000000000000000` (0.005 ETH) | `10925036` (~0.00000001 ETH) |
+
+- 스왑 금액(`5000000000000000` wei = 0.005 ETH)은 calldata에 정상 인코딩됨
+- 그러나 `txdata.value`(= EVM 트랜잭션의 `msg.value`)는 ~10,925,036 wei (프로토콜 수수료/팁으로 추정)
+- DEX 라우터는 `msg.value`로 실제 ETH를 수령하므로, 스왑 금액만큼의 ETH가 전달되지 않아 revert
+
+### 코드 경로
+
+`packages/actions/src/providers/dcent-swap/dex-swap.ts` (line 264):
+
+```typescript
+value: txdata.value ? BigInt(txdata.value).toString() : '0',
+```
+
+- DCent API가 반환한 `txdata.value`를 그대로 사용
+- 네이티브 ETH 매도(isNativeSell)인 경우에도 별도 value 보정 없음
+
+### 유닛 테스트와의 불일치
+
+`dcent-dex-swap.test.ts` (line 80) mock fixture:
+
+```typescript
+value: '1000000000000000000',  // 1 ETH = 스왑 금액과 동일
+```
+
+테스트는 DCent API가 스왑 금액을 `txdata.value`에 포함하여 반환한다고 가정하나, 실제 API는 프로토콜 수수료만 반환한다.
+
+## 영향
+
+- **모든 네이티브 자산 매도 스왑**이 온체인에서 revert (ETH→USDC, ETH→USDT 등)
+- ERC-20 매도 스왑(USDC→ETH 등)은 `value: '0'`이므로 영향 없음
+- dryRun과 실제 실행 모두 동일하게 실패
+
+## 수정 방안
+
+### A. 네이티브 매도 시 value 보정 (권장)
+
+`dex-swap.ts`에서 `isNativeSell`일 때, `txdata.value`가 `params.amount`보다 작으면 `params.amount`를 value로 사용하거나 합산:
+
+```typescript
+// 수정안
+let swapValue = txdata.value ? BigInt(txdata.value).toString() : '0';
+if (isNativeSell) {
+  const apiValue = BigInt(swapValue);
+  const swapAmount = BigInt(params.amount);
+  if (apiValue < swapAmount) {
+    // DCent API가 프로토콜 수수료만 반환 → 스왑 금액으로 대체
+    // 또는 swapAmount + apiValue (수수료 포함)
+    swapValue = swapAmount.toString();
+  }
+}
+```
+
+### B. DCent API 문의
+
+DCent 측에 `txdata.value` 반환 규격 확인. 네이티브 자산 스왑 시 value에 스왑 금액을 포함해야 하는지, 프로토콜 수수료만 반환하는 것이 의도인지 확인.
+
+### C. 테스트 fixture 현실화
+
+mock fixture의 `value`를 실제 API 응답 패턴(프로토콜 수수료 값)으로 수정하고, 보정 로직을 테스트.
+
+## 수정 대상 파일
+
+- `packages/actions/src/providers/dcent-swap/dex-swap.ts` — value 보정 로직 추가 (line 259-265)
+- `packages/actions/src/__tests__/dcent-dex-swap.test.ts` — native sell value 보정 테스트 추가
+
+## 테스트 항목
+
+1. **유닛 테스트**: 네이티브 ETH 매도 시 `txdata.value < params.amount`이면 value가 `params.amount`로 보정되는지 검증
+2. **유닛 테스트**: 네이티브 ETH 매도 시 `txdata.value >= params.amount`이면 API 값 그대로 사용되는지 검증
+3. **유닛 테스트**: ERC-20 매도 시 value 보정 로직이 적용되지 않는지 검증 (기존 동작 유지)
+4. **통합 테스트**: 실제 DCent API로 ETH→USDC dryRun 시 simulation.success: true 확인

--- a/internal/objectives/issues/394-dcent-swap-solana-txdata-schema-mismatch.md
+++ b/internal/objectives/issues/394-dcent-swap-solana-txdata-schema-mismatch.md
@@ -1,0 +1,123 @@
+# 394 — DCent Swap Solana 트랜잭션 스키마 불일치로 Solana 체인 스왑 전면 실패
+
+- **유형:** BUG
+- **심각도:** HIGH
+- **상태:** FIXED
+- **마일스톤:** (미정)
+- **발견일:** 2026-03-19
+
+## 현상
+
+`POST /v1/actions/dcent_swap/dex_swap` (또는 `?dryRun=true`)으로 Solana 네이티브 스왑(SOL→USDC) 실행 시 Zod 스키마 검증 실패:
+
+```
+DCent API error: [
+  { "path": ["txdata", "from"], "message": "Required" },
+  { "path": ["txdata", "to"], "message": "Required" }
+]
+```
+
+DCent API가 Solana 트랜잭션 데이터를 반환했으나, WAIaaS의 `DcentTxDataResponseSchema`가 EVM 전용 필드(`from`, `to`, `data`)를 필수로 요구하여 파싱 실패.
+
+## 원인
+
+### 1. EVM 전용 응답 스키마
+
+`packages/actions/src/providers/dcent-swap/schemas.ts` (line 71-83):
+
+```typescript
+export const DcentTxDataResponseSchema = z.object({
+  status: z.string(),
+  txdata: z.object({
+    from: z.string(),     // ← EVM 전용: Solana 응답에 없음
+    to: z.string(),       // ← EVM 전용: Solana 응답에 없음
+    data: z.string(),     // ← EVM calldata: Solana는 serialized tx bytes
+    value: z.string().optional(),
+  }).optional(),
+  ...
+});
+```
+
+Solana 트랜잭션 형식은 serialized transaction bytes (base64/base58)로, EVM의 `{from, to, data, value}` 구조와 완전히 다름.
+
+### 2. EVM 전용 실행 로직
+
+`packages/actions/src/providers/dcent-swap/dex-swap.ts` (line 259-265):
+
+```typescript
+const swapRequest: ContractCallRequest = {
+  type: 'CONTRACT_CALL',   // ← EVM 전용 타입
+  to: txdata.to,            // ← Solana에서는 undefined
+  calldata: txdata.data,    // ← Solana에서는 undefined
+  value: txdata.value ? BigInt(txdata.value).toString() : '0',
+};
+```
+
+- 체인 감지 로직 없음: EVM인지 Solana인지 판별하지 않음
+- Solana 트랜잭션을 `CONTRACT_CALL`로 래핑할 수 없음 (SIGN 타입 필요)
+
+### 3. 메타데이터는 Solana 지원 선언
+
+`packages/actions/src/providers/dcent-swap/index.ts` (line 86):
+
+```typescript
+chains: ['ethereum', 'solana'],  // ← Solana 지원 선언
+```
+
+`currency-mapper.ts`도 Solana CAIP-19 변환을 지원하고, `auto-router.ts`도 Solana 중간 토큰(SOL, USDC)을 포함. 그러나 실제 실행 경로(`dex-swap.ts`)는 EVM만 처리.
+
+## 영향
+
+- **Solana 체인의 모든 DCent 스왑이 실패**: SOL→SPL, SPL→SPL, SPL→SOL
+- 크로스체인 EVM→Solana 스왑도 Solana 측 트랜잭션 처리에서 동일 문제 발생 가능
+- 메타데이터가 Solana 지원을 선언하므로 MCP/SDK에서 Solana 스왑을 시도할 수 있으나, 항상 실패
+
+## 수정 방안
+
+### A. Solana txdata 스키마 확장 + 체인별 분기 (권장)
+
+1. DCent API의 Solana 응답 형식 파악 (serialized transaction bytes 예상)
+2. `DcentTxDataResponseSchema`를 discriminatedUnion 또는 union으로 확장:
+
+```typescript
+const EvmTxData = z.object({
+  from: z.string(),
+  to: z.string(),
+  data: z.string(),
+  value: z.string().optional(),
+});
+
+const SolanaTxData = z.object({
+  serializedTx: z.string(),  // base64 or base58
+  // Solana 고유 필드 추가
+});
+
+txdata: z.union([EvmTxData, SolanaTxData]).optional(),
+```
+
+3. `dex-swap.ts`에 체인 감지 + Solana 분기 추가:
+   - Solana: `{ type: 'SIGN', data: serializedTx }` 형태로 반환
+   - EVM: 기존 `CONTRACT_CALL` 로직 유지
+
+### B. Solana 지원 임시 제거
+
+`chains: ['ethereum']`으로 변경하고, Solana 스왑은 Jupiter Swap 프로바이더로 라우팅. DCent Solana 지원이 확인될 때까지 보류.
+
+### C. DCent API Solana 응답 규격 확인
+
+DCent 측에 Solana 트랜잭션 응답 형식 문의. 실제 `txdata` 구조를 확인한 후 스키마 및 핸들러 구현.
+
+## 수정 대상 파일
+
+- `packages/actions/src/providers/dcent-swap/schemas.ts` — Solana txdata 스키마 추가
+- `packages/actions/src/providers/dcent-swap/dex-swap.ts` — 체인 감지 및 Solana 분기 로직
+- `packages/actions/src/providers/dcent-swap/index.ts` — (B안 시) chains 배열 수정
+- `packages/actions/src/__tests__/dcent-dex-swap.test.ts` — Solana 스왑 테스트 추가
+
+## 테스트 항목
+
+1. **유닛 테스트**: Solana CAIP-19 입력(solana:5eykt.../slip44:501) 시 체인이 'solana'로 감지되는지 검증
+2. **유닛 테스트**: Solana txdata 응답이 Solana 스키마로 파싱되는지 검증
+3. **유닛 테스트**: Solana 스왑 결과가 SIGN 타입 요청으로 반환되는지 검증
+4. **유닛 테스트**: EVM 스왑의 기존 동작(CONTRACT_CALL)이 변경되지 않는지 회귀 검증
+5. **통합 테스트**: Solana 네이티브 스왑(SOL→USDC) dryRun 성공 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -38,6 +38,10 @@
 | 388 | BUG | MEDIUM | defi-12 DCent Swap UAT 시나리오 API 엔드포인트 오류 — /v1/transactions/* 대신 /v1/actions/dcent_swap/* 사용 필요 | v32.9 | FIXED | 2026-03-18 |
 | 389 | ENHANCEMENT | LOW | Agent UAT 시나리오 환경(Environment) 분류 누락 — Env 컬럼 및 --env 필터 추가 필요 | v32.9 | FIXED | 2026-03-18 |
 | 390 | BUG | CRITICAL | Migration v60 CHECK 제약조건 미갱신으로 sdk_push UPDATE 실패 — 기존 DB 업그레이드 시 데몬 시작 불가 | v32.10 | FIXED | 2026-03-18 |
+| 391 | BUG | MEDIUM | Polygon Amoy 빌트인 토큰 3개(AAVE/DAI/USDT) 컨트랙트 미존재로 매 요청마다 에러 로그 발생 | — | FIXED | 2026-03-19 |
+| 392 | BUG | CRITICAL | PositionTracker가 지갑 UUID를 온체인 주소로 사용하여 모든 DeFi 포지션 조회 실패 | — | FIXED | 2026-03-19 |
+| 393 | BUG | HIGH | DCent Swap 네이티브 ETH 스왑 시 txdata.value 불일치로 온체인 revert — API가 프로토콜 수수료만 반환, 스왑 금액 누락 | — | FIXED | 2026-03-19 |
+| 394 | BUG | HIGH | DCent Swap Solana 트랜잭션 스키마 불일치로 Solana 체인 스왑 전면 실패 — EVM 전용 txdata 스키마, 체인 분기 없음 | — | FIXED | 2026-03-19 |
 
 ## Type Legend
 
@@ -50,7 +54,7 @@
 ## Summary
 
 - **OPEN:** 0
-- **FIXED:** 390
+- **FIXED:** 394
 - **WONTFIX:** 1
-- **Total:** 391
+- **Total:** 395
 - **Archived:** 366 (001–366)

--- a/packages/actions/src/__tests__/aave-v3-positions.test.ts
+++ b/packages/actions/src/__tests__/aave-v3-positions.test.ts
@@ -152,6 +152,7 @@ const MOCK_ETH_RPC = 'https://mock-eth-rpc.example.com';
 function makeEvmCtx(walletId: string = WALLET_ADDRESS, chain: 'ethereum' | 'solana' = 'ethereum'): PositionQueryContext {
   return {
     walletId,
+    walletAddress: walletId,
     chain,
     networks: chain === 'ethereum' ? ['ethereum-mainnet'] : ['solana-mainnet'],
     environment: 'mainnet',
@@ -343,6 +344,7 @@ describe('AaveV3LendingProvider.getPositions()', () => {
     const provider = new AaveV3LendingProvider({});
     const ctx: PositionQueryContext = {
       walletId: WALLET_ADDRESS,
+      walletAddress: WALLET_ADDRESS,
       chain: 'ethereum',
       networks: ['ethereum-mainnet'],
       environment: 'mainnet',
@@ -420,6 +422,7 @@ describe('AaveV3LendingProvider Multichain Positions', () => {
   }): PositionQueryContext {
     return {
       walletId: WALLET_ADDRESS,
+      walletAddress: WALLET_ADDRESS,
       chain: 'ethereum',
       networks: (opts?.networks ?? ['ethereum-mainnet', 'base-mainnet']) as any,
       environment: opts?.environment ?? 'mainnet',

--- a/packages/actions/src/__tests__/aave-v3-provider.test.ts
+++ b/packages/actions/src/__tests__/aave-v3-provider.test.ts
@@ -412,7 +412,7 @@ describe('IPositionProvider compliance', () => {
   });
 
   it('should return empty positions when no rpcCaller', async () => {
-    const ctx: PositionQueryContext = { walletId: 'test-wallet', chain: 'ethereum', networks: ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
+    const ctx: PositionQueryContext = { walletId: 'test-wallet', walletAddress: 'test-wallet', chain: 'ethereum', networks: ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
     const positions = await provider.getPositions(ctx);
     expect(positions).toEqual([]);
   });

--- a/packages/actions/src/__tests__/dcent-dex-swap.test.ts
+++ b/packages/actions/src/__tests__/dcent-dex-swap.test.ts
@@ -588,7 +588,7 @@ describe('dcent-dex-swap', () => {
       expect(capturedQuoteBody!.fromWalletAddress).toBe('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
     });
 
-    it('handles txdata with no value (defaults to 0)', async () => {
+    it('corrects native sell value when API returns only protocol fees', async () => {
       server.use(
         http.post(`${BASE_URL}/api/swap/v3/get_dex_swap_transaction_data`, () => {
           return HttpResponse.json({
@@ -597,7 +597,7 @@ describe('dcent-dex-swap', () => {
               from: '0xwallet',
               to: SUSHI_SPENDER,
               data: '0xdata',
-              // value omitted (optional field)
+              value: '10925036', // protocol fee only, not swap amount
             },
           });
         }),
@@ -607,13 +607,63 @@ describe('dcent-dex-swap', () => {
       const result = await executeDexSwap(client, {
         fromAsset: ETH_CAIP19,
         toAsset: USDC_CAIP19,
-        amount: '1000000000000000000',
+        amount: '5000000000000000', // 0.005 ETH
         fromDecimals: 18,
         toDecimals: 6,
         walletAddress: '0xwallet',
       }, DEFAULT_CONFIG);
 
-      expect(result[0]!.value).toBe('0');
+      // Value should be corrected to swap amount since API value < swap amount
+      expect(result[0]!.value).toBe('5000000000000000');
+    });
+
+    it('keeps API value for native sell when API value >= swap amount', async () => {
+      const client = createClient();
+      const result = await executeDexSwap(client, {
+        fromAsset: ETH_CAIP19,
+        toAsset: USDC_CAIP19,
+        amount: '1000000000000000000',
+        fromDecimals: 18,
+        toDecimals: 6,
+        walletAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+      }, DEFAULT_CONFIG);
+
+      // Mock returns value: '1000000000000000000' which equals swap amount -> keep as-is
+      expect(result[0]!.value).toBe('1000000000000000000');
+    });
+
+    it('does not correct value for ERC-20 sell', async () => {
+      server.use(
+        http.post(`${BASE_URL}/api/swap/v3/get_quotes`, () => {
+          return HttpResponse.json(makeQuotesResponse({
+            fromId: 'ERC20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            toId: 'ETHEREUM',
+          }));
+        }),
+        http.post(`${BASE_URL}/api/swap/v3/get_dex_swap_transaction_data`, () => {
+          return HttpResponse.json(makeTxDataResponse({
+            txdata: {
+              from: '0xwallet',
+              to: SUSHI_SPENDER,
+              data: '0xswapdata',
+              value: '0',
+            },
+          }));
+        }),
+      );
+
+      const client = createClient();
+      const result = await executeDexSwap(client, {
+        fromAsset: USDC_CAIP19,
+        toAsset: ETH_CAIP19,
+        amount: '1000000',
+        fromDecimals: 6,
+        toDecimals: 18,
+        walletAddress: '0xwallet',
+      }, DEFAULT_CONFIG);
+
+      // ERC-20 sell: value stays as API returned ('0'), no correction
+      expect(result[1]!.value).toBe('0');
     });
   });
 });

--- a/packages/actions/src/__tests__/dcent-policy-integration.test.ts
+++ b/packages/actions/src/__tests__/dcent-policy-integration.test.ts
@@ -188,7 +188,7 @@ describe('DCent Swap policy integration', () => {
       expect(provider.metadata.name).toBe('dcent_swap');
       expect(provider.metadata.requiresApiKey).toBe(false);
       expect(provider.metadata.chains).toContain('ethereum');
-      expect(provider.metadata.chains).toContain('solana');
+      expect(provider.metadata.chains).not.toContain('solana');
     });
 
     it('provider has 2 actions defined (DEX-only)', () => {

--- a/packages/actions/src/__tests__/drift-provider.test.ts
+++ b/packages/actions/src/__tests__/drift-provider.test.ts
@@ -13,7 +13,7 @@ import { DRIFT_PROGRAM_ID } from '../providers/drift/config.js';
 import type { ActionContext, ContractCallRequest, PositionQueryContext } from '@waiaas/core';
 
 function makeSolCtx(walletId: string, chain: 'solana' | 'ethereum' = 'solana'): PositionQueryContext {
-  return { walletId, chain, networks: chain === 'solana' ? ['solana-mainnet'] : ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
+  return { walletId, walletAddress: walletId, chain, networks: chain === 'solana' ? ['solana-mainnet'] : ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
 }
 
 // ---------------------------------------------------------------------------
@@ -510,6 +510,7 @@ describe('IPositionProvider compliance', () => {
   it('should use ctx.networks[0] for network field (MCHN-08)', async () => {
     const ctx: PositionQueryContext = {
       walletId: 'test-wallet',
+      walletAddress: 'test-wallet',
       chain: 'solana',
       networks: ['solana-devnet'],
       environment: 'testnet',

--- a/packages/actions/src/__tests__/jito-staking.test.ts
+++ b/packages/actions/src/__tests__/jito-staking.test.ts
@@ -10,7 +10,7 @@ import { JITO_MAINNET_ADDRESSES, getJitoAddresses } from '../providers/jito-stak
 import type { ActionContext, ContractCallRequest, PositionQueryContext } from '@waiaas/core';
 
 function makeSolCtx(walletId: string, chain: 'solana' | 'ethereum' = 'solana'): PositionQueryContext {
-  return { walletId, chain, networks: chain === 'solana' ? ['solana-mainnet'] : ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
+  return { walletId, walletAddress: walletId, chain, networks: chain === 'solana' ? ['solana-mainnet'] : ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
 }
 
 // ---------------------------------------------------------------------------
@@ -404,6 +404,7 @@ describe('JitoStakingActionProvider IPositionProvider', () => {
 
     const ctx: PositionQueryContext = {
       walletId: WALLET_ID,
+      walletAddress: WALLET_ID,
       chain: 'solana',
       networks: ['solana-devnet'],
       environment: 'testnet',

--- a/packages/actions/src/__tests__/kamino-provider.test.ts
+++ b/packages/actions/src/__tests__/kamino-provider.test.ts
@@ -13,7 +13,7 @@ import { KAMINO_MAIN_MARKET } from '../providers/kamino/config.js';
 import type { ActionContext, ContractCallRequest, PositionQueryContext } from '@waiaas/core';
 
 function makeSolCtx(walletId: string, chain: 'solana' | 'ethereum' = 'solana'): PositionQueryContext {
-  return { walletId, chain, networks: chain === 'solana' ? ['solana-mainnet'] : ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
+  return { walletId, walletAddress: walletId, chain, networks: chain === 'solana' ? ['solana-mainnet'] : ['ethereum-mainnet'], environment: 'mainnet', rpcUrls: {} };
 }
 
 // ---------------------------------------------------------------------------
@@ -579,6 +579,7 @@ describe('IPositionProvider compliance', () => {
   it('should use ctx.networks[0] for network field (MCHN-08)', async () => {
     const ctx: PositionQueryContext = {
       walletId: 'test-wallet',
+      walletAddress: 'test-wallet',
       chain: 'solana',
       networks: ['solana-devnet'],
       environment: 'testnet',

--- a/packages/actions/src/__tests__/lido-staking.test.ts
+++ b/packages/actions/src/__tests__/lido-staking.test.ts
@@ -224,6 +224,7 @@ describe('LidoStakingActionProvider IPositionProvider', () => {
   function makeCtx(walletId: string = WALLET_ID, chain: 'ethereum' | 'solana' = 'ethereum'): PositionQueryContext {
     return {
       walletId,
+      walletAddress: walletId,
       chain,
       networks: chain === 'ethereum' ? ['ethereum-mainnet'] : ['solana-mainnet'],
       environment: 'mainnet',
@@ -403,6 +404,7 @@ describe('LidoStakingActionProvider Multichain Positions', () => {
   }): PositionQueryContext {
     return {
       walletId: WALLET_ID,
+      walletAddress: WALLET_ID,
       chain: 'ethereum',
       networks: (opts?.networks ?? ['ethereum-mainnet', 'base-mainnet']) as any,
       environment: opts?.environment ?? 'mainnet',

--- a/packages/actions/src/__tests__/pendle-positions.test.ts
+++ b/packages/actions/src/__tests__/pendle-positions.test.ts
@@ -33,6 +33,7 @@ function makeMultiCtx(opts?: {
 }): PositionQueryContext {
   return {
     walletId: WALLET_ID,
+    walletAddress: WALLET_ID,
     chain: 'ethereum',
     networks: (opts?.networks ?? ['ethereum-mainnet', 'arbitrum-mainnet']) as any,
     environment: 'mainnet',

--- a/packages/actions/src/providers/aave-v3/index.ts
+++ b/packages/actions/src/providers/aave-v3/index.ts
@@ -445,7 +445,7 @@ export class AaveV3LendingProvider implements ILendingProvider, IPositionProvide
 
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'ethereum') return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
 
     // Filter ctx.networks to only AAVE_V3_ADDRESSES-supported networks (MCHN-02)
     const supportedNetworks = ctx.networks.filter(n => AAVE_V3_ADDRESSES[n]);
@@ -456,7 +456,7 @@ export class AaveV3LendingProvider implements ILendingProvider, IPositionProvide
       supportedNetworks.map(network => {
         const rpcUrl = ctx.rpcUrls[network];
         if (!rpcUrl) return Promise.resolve([] as PositionUpdate[]);
-        return this.queryNetworkAavePositions(walletId, network, rpcUrl);
+        return this.queryNetworkAavePositions(ctx.walletId, walletAddress, network, rpcUrl);
       }),
     );
 
@@ -469,6 +469,7 @@ export class AaveV3LendingProvider implements ILendingProvider, IPositionProvide
    */
   private async queryNetworkAavePositions(
     walletId: string,
+    walletAddress: string,
     network: string,
     rpcUrl: string,
   ): Promise<PositionUpdate[]> {
@@ -487,7 +488,7 @@ export class AaveV3LendingProvider implements ILendingProvider, IPositionProvide
     const prices = decodeUint256Array(pricesHex); // 8 decimals USD
 
     // 3. Get user account data (for Health Factor)
-    const accountDataHex = await this.rpcCall(rpcUrl, addresses.pool, encodeGetUserAccountDataCalldata(walletId));
+    const accountDataHex = await this.rpcCall(rpcUrl, addresses.pool, encodeGetUserAccountDataCalldata(walletAddress));
     const accountData = decodeGetUserAccountData(accountDataHex);
     const healthFactor = hfToNumber(accountData.healthFactor);
 
@@ -499,10 +500,10 @@ export class AaveV3LendingProvider implements ILendingProvider, IPositionProvide
       const tokensHex = await this.rpcCall(rpcUrl, addresses.dataProvider, encodeGetReserveTokensAddressesCalldata(asset));
       const tokens = decodeReserveTokensAddresses(tokensHex);
 
-      const aBalHex = await this.rpcCall(rpcUrl, tokens.aToken, encodeBalanceOfCalldata(walletId));
+      const aBalHex = await this.rpcCall(rpcUrl, tokens.aToken, encodeBalanceOfCalldata(walletAddress));
       const aBalance = BigInt(aBalHex.length > 2 ? aBalHex : '0x0');
 
-      const vBalHex = await this.rpcCall(rpcUrl, tokens.variableDebtToken, encodeBalanceOfCalldata(walletId));
+      const vBalHex = await this.rpcCall(rpcUrl, tokens.variableDebtToken, encodeBalanceOfCalldata(walletAddress));
       const vBalance = BigInt(vBalHex.length > 2 ? vBalHex : '0x0');
 
       if (aBalance === 0n && vBalance === 0n) continue;

--- a/packages/actions/src/providers/dcent-swap/dex-swap.ts
+++ b/packages/actions/src/providers/dcent-swap/dex-swap.ts
@@ -256,12 +256,22 @@ export async function executeDexSwap(
     requests.push(approveRequest);
   }
 
-  // Swap request
+  // Swap request — for native sells, DCent API may return only protocol fees
+  // in txdata.value instead of the full swap amount; correct to params.amount
+  let swapValue = txdata.value ? BigInt(txdata.value).toString() : '0';
+  if (isNativeSell) {
+    const apiValue = BigInt(swapValue);
+    const swapAmount = BigInt(params.amount);
+    if (apiValue < swapAmount) {
+      swapValue = swapAmount.toString();
+    }
+  }
+
   const swapRequest: ContractCallRequest = {
     type: 'CONTRACT_CALL',
     to: txdata.to,
     calldata: txdata.data,
-    value: txdata.value ? BigInt(txdata.value).toString() : '0',
+    value: swapValue,
   };
   requests.push(swapRequest);
 

--- a/packages/actions/src/providers/dcent-swap/index.ts
+++ b/packages/actions/src/providers/dcent-swap/index.ts
@@ -83,7 +83,7 @@ export class DcentSwapActionProvider implements IActionProvider {
       displayName: "D'CENT Swap",
       description: "D'CENT Swap Aggregator supporting multi-chain DEX swaps including cross-chain swaps",
       version: '1.0.0',
-      chains: ['ethereum', 'solana'],
+      chains: ['ethereum'],
       mcpExpose: true,
       requiresApiKey: false,
       requiredApis: [],

--- a/packages/actions/src/providers/drift/index.ts
+++ b/packages/actions/src/providers/drift/index.ts
@@ -347,13 +347,13 @@ export class DriftPerpProvider implements IPerpProvider, IPositionProvider {
 
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'solana') return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
     const network = ctx.networks[0] ?? 'solana-mainnet';
     try {
-      const positions = await this.sdkWrapper.getPositions(walletId);
+      const positions = await this.sdkWrapper.getPositions(walletAddress);
       const now = Math.floor(Date.now() / 1000);
       return positions.map((pos) => ({
-        walletId,
+        walletId: ctx.walletId,
         category: 'PERP' as PositionCategory,
         provider: 'drift_perp',
         chain: 'solana',

--- a/packages/actions/src/providers/hyperliquid/__tests__/perp-provider.test.ts
+++ b/packages/actions/src/providers/hyperliquid/__tests__/perp-provider.test.ts
@@ -10,7 +10,7 @@ import type { HyperliquidMarketData } from '../market-data.js';
 import type { ActionContext, PositionQueryContext } from '@waiaas/core';
 
 function makeEvmCtx(walletId: string = 'wallet-001', chain: 'ethereum' | 'solana' = 'ethereum'): PositionQueryContext {
-  return { walletId, chain, networks: chain === 'ethereum' ? ['ethereum-mainnet'] : ['solana-mainnet'], environment: 'mainnet', rpcUrls: {} };
+  return { walletId, walletAddress: `0x${walletId}`, chain, networks: chain === 'ethereum' ? ['ethereum-mainnet'] : ['solana-mainnet'], environment: 'mainnet', rpcUrls: {} };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/actions/src/providers/hyperliquid/__tests__/spot-provider.test.ts
+++ b/packages/actions/src/providers/hyperliquid/__tests__/spot-provider.test.ts
@@ -10,7 +10,7 @@ import type { HyperliquidMarketData } from '../market-data.js';
 import type { ActionContext, PositionQueryContext } from '@waiaas/core';
 
 function makeEvmCtx(walletId: string = 'wallet-001', chain: 'ethereum' | 'solana' = 'ethereum'): PositionQueryContext {
-  return { walletId, chain, networks: chain === 'ethereum' ? ['ethereum-mainnet'] : ['solana-mainnet'], environment: 'mainnet', rpcUrls: {} };
+  return { walletId, walletAddress: `0x${walletId}`, chain, networks: chain === 'ethereum' ? ['ethereum-mainnet'] : ['solana-mainnet'], environment: 'mainnet', rpcUrls: {} };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/actions/src/providers/hyperliquid/perp-provider.ts
+++ b/packages/actions/src/providers/hyperliquid/perp-provider.ts
@@ -820,10 +820,10 @@ export class HyperliquidPerpProvider implements IPerpProvider {
 
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'ethereum') return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
     try {
       const [positions, mids] = await Promise.all([
-        this.marketData.getPositions(walletId as Hex),
+        this.marketData.getPositions(walletAddress as Hex),
         this.marketData.getAllMidPrices(),
       ]);
 
@@ -836,7 +836,7 @@ export class HyperliquidPerpProvider implements IPerpProvider {
         const absSize = Math.abs(szi);
 
         return {
-          walletId,
+          walletId: ctx.walletId,
           category: 'PERP' as PositionCategory,
           provider: 'hyperliquid_perp',
           chain: 'ethereum',

--- a/packages/actions/src/providers/hyperliquid/spot-provider.ts
+++ b/packages/actions/src/providers/hyperliquid/spot-provider.ts
@@ -363,10 +363,10 @@ export class HyperliquidSpotProvider implements IActionProvider {
 
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'ethereum') return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
     try {
       const [balances, mids] = await Promise.all([
-        this.marketData.getSpotBalances(walletId as Hex),
+        this.marketData.getSpotBalances(walletAddress as Hex),
         this.marketData.getAllMidPrices(),
       ]);
 
@@ -388,7 +388,7 @@ export class HyperliquidSpotProvider implements IActionProvider {
           }
 
           return {
-            walletId,
+            walletId: ctx.walletId,
             category: 'PERP' as PositionCategory,
             provider: 'hyperliquid_spot',
             chain: 'ethereum',

--- a/packages/actions/src/providers/jito-staking/index.ts
+++ b/packages/actions/src/providers/jito-staking/index.ts
@@ -167,13 +167,13 @@ export class JitoStakingActionProvider implements IActionProvider {
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'solana') return [];
     if (!this.rpcUrl) return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
     const network = ctx.networks[0] ?? 'solana-mainnet';
 
     try {
       const balance = await getJitoSolBalance(
         this.rpcUrl,
-        walletId,
+        walletAddress,
         this.config.jitosolMint,
       );
 
@@ -192,7 +192,7 @@ export class JitoStakingActionProvider implements IActionProvider {
 
       return [
         {
-          walletId,
+          walletId: ctx.walletId,
           category: 'STAKING' as PositionCategory,
           provider: 'jito_staking',
           chain: 'solana',

--- a/packages/actions/src/providers/kamino/index.ts
+++ b/packages/actions/src/providers/kamino/index.ts
@@ -421,13 +421,13 @@ export class KaminoLendingProvider implements ILendingProvider, IPositionProvide
 
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'solana') return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
     const network = ctx.networks[0] ?? 'solana-mainnet';
     try {
       const marketAddress = resolveMarketAddress(this.config.market);
       const obligation = await this.sdkWrapper.getObligation({
         market: marketAddress,
-        walletAddress: walletId,
+        walletAddress,
       });
       if (!obligation) return [];
 
@@ -436,7 +436,7 @@ export class KaminoLendingProvider implements ILendingProvider, IPositionProvide
 
       for (const deposit of obligation.deposits) {
         updates.push({
-          walletId,
+          walletId: ctx.walletId,
           category: 'LENDING' as const,
           provider: 'kamino',
           chain: 'solana',
@@ -452,7 +452,7 @@ export class KaminoLendingProvider implements ILendingProvider, IPositionProvide
 
       for (const borrow of obligation.borrows) {
         updates.push({
-          walletId,
+          walletId: ctx.walletId,
           category: 'LENDING' as const,
           provider: 'kamino',
           chain: 'solana',

--- a/packages/actions/src/providers/lido-staking/index.ts
+++ b/packages/actions/src/providers/lido-staking/index.ts
@@ -186,7 +186,7 @@ export class LidoStakingActionProvider implements IActionProvider {
    */
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'ethereum') return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
 
     // Select config map based on environment (MCHN-10)
     const networkConfig = ctx.environment === 'testnet'
@@ -202,7 +202,7 @@ export class LidoStakingActionProvider implements IActionProvider {
       supportedNetworks.map(network => {
         const rpcUrl = ctx.rpcUrls[network];
         if (!rpcUrl) return Promise.resolve([] as PositionUpdate[]);
-        return this.queryNetworkPositions(walletId, network, networkConfig[network]!, rpcUrl);
+        return this.queryNetworkPositions(ctx.walletId, walletAddress, network, networkConfig[network]!, rpcUrl);
       }),
     );
 
@@ -215,6 +215,7 @@ export class LidoStakingActionProvider implements IActionProvider {
    */
   private async queryNetworkPositions(
     walletId: string,
+    walletAddress: string,
     network: string,
     config: LidoNetworkContracts,
     rpcUrl: string,
@@ -227,7 +228,7 @@ export class LidoStakingActionProvider implements IActionProvider {
       const stethBalance = await this.ethCallUint256WithRpc(
         rpcUrl,
         config.stethAddress,
-        encodeBalanceOfCalldata(walletId),
+        encodeBalanceOfCalldata(walletAddress),
       );
 
       if (stethBalance > 0n) {
@@ -252,7 +253,7 @@ export class LidoStakingActionProvider implements IActionProvider {
     const wstethBalance = await this.ethCallUint256WithRpc(
       rpcUrl,
       config.wstethAddress,
-      encodeBalanceOfCalldata(walletId),
+      encodeBalanceOfCalldata(walletAddress),
     );
 
     if (wstethBalance > 0n) {

--- a/packages/actions/src/providers/pendle/__tests__/pendle-provider.test.ts
+++ b/packages/actions/src/providers/pendle/__tests__/pendle-provider.test.ts
@@ -309,6 +309,7 @@ describe('PendleYieldProvider', () => {
           : {};
       return {
         walletId: WALLET_ADDRESS,
+        walletAddress: WALLET_ADDRESS,
         chain,
         networks: chain === 'ethereum' ? ['ethereum-mainnet'] : ['solana-mainnet'],
         environment: 'mainnet',

--- a/packages/actions/src/providers/pendle/index.ts
+++ b/packages/actions/src/providers/pendle/index.ts
@@ -304,7 +304,7 @@ export class PendleYieldProvider implements IYieldProvider, IPositionProvider {
 
   async getPositions(ctx: PositionQueryContext): Promise<PositionUpdate[]> {
     if (ctx.chain !== 'ethereum') return [];
-    const walletId = ctx.walletId;
+    const walletAddress = ctx.walletAddress;
 
     // Filter ctx.networks to only Pendle position-supported networks (MCHN-03)
     const supportedNetworks = ctx.networks.filter(
@@ -317,7 +317,7 @@ export class PendleYieldProvider implements IYieldProvider, IPositionProvider {
       supportedNetworks.map(network => {
         const rpcUrl = ctx.rpcUrls[network];
         if (!rpcUrl) return Promise.resolve([] as PositionUpdate[]);
-        return this.queryNetworkPendlePositions(walletId, network, rpcUrl);
+        return this.queryNetworkPendlePositions(ctx.walletId, walletAddress, network, rpcUrl);
       }),
     );
 
@@ -330,6 +330,7 @@ export class PendleYieldProvider implements IYieldProvider, IPositionProvider {
    */
   private async queryNetworkPendlePositions(
     walletId: string,
+    walletAddress: string,
     network: string,
     rpcUrl: string,
   ): Promise<PositionUpdate[]> {
@@ -346,7 +347,7 @@ export class PendleYieldProvider implements IYieldProvider, IPositionProvider {
       const underlyingAsset = market.underlyingAsset.symbol;
 
       // Check PT balance
-      const ptBalance = await this.ethCallUint256WithRpc(rpcUrl, market.pt, this.encodeBalanceOfCalldata(walletId));
+      const ptBalance = await this.ethCallUint256WithRpc(rpcUrl, market.pt, this.encodeBalanceOfCalldata(walletAddress));
       if (ptBalance > 0n) {
         positions.push({
           walletId,
@@ -370,7 +371,7 @@ export class PendleYieldProvider implements IYieldProvider, IPositionProvider {
       }
 
       // Check YT balance
-      const ytBalance = await this.ethCallUint256WithRpc(rpcUrl, market.yt, this.encodeBalanceOfCalldata(walletId));
+      const ytBalance = await this.ethCallUint256WithRpc(rpcUrl, market.yt, this.encodeBalanceOfCalldata(walletAddress));
       if (ytBalance > 0n) {
         positions.push({
           walletId,

--- a/packages/core/src/interfaces/position-provider.types.ts
+++ b/packages/core/src/interfaces/position-provider.types.ts
@@ -38,6 +38,7 @@ export interface PositionUpdate {
  */
 export interface PositionQueryContext {
   walletId: string;
+  walletAddress: string; // on-chain address (0x... or base58)
   chain: ChainType;
   networks: readonly NetworkType[];
   environment: EnvironmentType;

--- a/packages/daemon/src/infrastructure/token-registry/builtin-tokens.ts
+++ b/packages/daemon/src/infrastructure/token-registry/builtin-tokens.ts
@@ -105,16 +105,13 @@ export const BUILTIN_TOKENS: Record<string, TokenEntry[]> = {
   ],
 
   // ---------------------------------------------------------------------------
-  // Polygon Amoy (7 tokens)
+  // Polygon Amoy (4 tokens — AAVE/DAI/USDT removed: contracts no longer exist after testnet reset)
   // ---------------------------------------------------------------------------
   'polygon-amoy': [
     { address: '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582', symbol: 'USDC', name: 'USD Coin', decimals: 6 },
-    { address: '0x1fdE0eCc619726f4cD597887C9F3b4c8740e19e2', symbol: 'USDT', name: 'Tether USD', decimals: 6 },
     { address: '0x52eF3d68BaB452a294342DC3e5f464d7f610f72E', symbol: 'WETH', name: 'Wrapped Ether', decimals: 18 },
-    { address: '0xc8c0Cf9436F4862a8F60Ce680Ca5a9f0f99b5ded', symbol: 'DAI', name: 'Dai Stablecoin', decimals: 18 },
     { address: '0x0Fd9e8d3aF1aaee056EB9e802c3A762a667b1904', symbol: 'LINK', name: 'Chainlink', decimals: 18 },
     { address: '0x360ad4f9a9A8EFe9A8DCB5f461c4Cc1047E1Dcf9', symbol: 'WPOL', name: 'Wrapped POL', decimals: 18 },
-    { address: '0x1558c6FadDe1bEaf0f6628BDd1DFf3461185eA24', symbol: 'AAVE', name: 'Aave Token', decimals: 18 },
   ],
 
   // ---------------------------------------------------------------------------

--- a/packages/daemon/src/services/defi/position-tracker.ts
+++ b/packages/daemon/src/services/defi/position-tracker.ts
@@ -153,8 +153,8 @@ export class PositionTracker {
 
       // Get active wallets with chain/environment metadata
       const wallets = this.sqlite
-        .prepare("SELECT id, chain, environment FROM wallets WHERE status = 'ACTIVE'")
-        .all() as Array<{ id: string; chain: string; environment: string }>;
+        .prepare("SELECT id, public_key, chain, environment FROM wallets WHERE status = 'ACTIVE'")
+        .all() as Array<{ id: string; public_key: string; chain: string; environment: string }>;
 
       for (const provider of categoryProviders) {
         for (const wallet of wallets) {
@@ -178,6 +178,7 @@ export class PositionTracker {
             }
             const ctx: PositionQueryContext = {
               walletId: wallet.id,
+              walletAddress: wallet.public_key,
               chain,
               networks,
               environment,


### PR DESCRIPTION
## Summary

- **#391** (MEDIUM): Remove 3 invalid Polygon Amoy builtin tokens (AAVE/DAI/USDT) — contracts no longer exist after testnet reset, causing repeated error logs and fallback overhead on every balance query
- **#392** (CRITICAL): Fix PositionTracker using wallet UUID (v7) instead of blockchain address for all on-chain RPC calls — all 7 DeFi position providers were querying with wrong address, resulting in empty `defi_positions` table and non-functional DeFi dashboard
- **#393** (HIGH): Fix DCent Swap native ETH sell value mismatch — API returns only protocol fees in `txdata.value`, not swap amount, causing on-chain revert on all native coin swaps
- **#394** (HIGH): Remove Solana from DCent Swap supported chains — execution path is EVM-only (`CONTRACT_CALL`), Solana txdata schema incompatible. Solana swaps route to Jupiter Swap instead

## Changes

- Add `walletAddress` field to `PositionQueryContext` interface
- Update `PositionTracker` to query `public_key` from wallets table
- Update all 7 position providers (Lido, Aave V3, Pendle, Jito, Kamino, Drift, Hyperliquid) to use `walletAddress` for on-chain calls
- Add native sell value correction logic in DCent Swap `dex-swap.ts`
- Remove `solana` from DCent Swap metadata `chains` array
- Remove 3 invalid Polygon Amoy token entries from `builtin-tokens.ts`
- Update all position provider tests to include `walletAddress` in context
- Add DCent Swap native sell value correction tests
- Update issue tracker: 4 OPEN → FIXED

## Test plan

- [x] `pnpm turbo run typecheck` — 21/21 passed
- [x] `pnpm turbo run lint` — 0 errors
- [x] `pnpm turbo run test:unit --filter=@waiaas/actions` — 1357/1357 passed
- [x] `pnpm turbo run test:unit --filter=@waiaas/daemon` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)