### PR TITLE
fix: resolve Kamino/Drift RPC URL, Pendle schema regression, and DCent decimals auto-resolution

### DIFF
--- a/agent-uat/defi/dcent-swap.md
+++ b/agent-uat/defi/dcent-swap.md
@@ -50,7 +50,9 @@ curl -s -X POST 'http://localhost:3100/v1/actions/dcent_swap/dex_swap?dryRun=tru
       "fromAsset": "eip155:1/slip44:60",
       "toAsset": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "amount": "1000000000000000",
-      "slippageBps": 50
+      "slippageBps": 50,
+      "fromDecimals": 18,
+      "toDecimals": 6
     }
   }'
 ```
@@ -79,7 +81,9 @@ curl -s -X POST http://localhost:3100/v1/actions/dcent_swap/dex_swap \
       "fromAsset": "eip155:1/slip44:60",
       "toAsset": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "amount": "1000000000000000",
-      "slippageBps": 50
+      "slippageBps": 50,
+      "fromDecimals": 18,
+      "toDecimals": 6
     }
   }'
 ```
@@ -145,7 +149,9 @@ curl -s -X POST 'http://localhost:3100/v1/actions/dcent_swap/dex_swap?dryRun=tru
       "fromAsset": "eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F",
       "toAsset": "eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA",
       "amount": "10000000000000000000",
-      "slippageBps": 100
+      "slippageBps": 100,
+      "fromDecimals": 18,
+      "toDecimals": 18
     }
   }'
 ```
@@ -164,7 +170,9 @@ curl -s -X POST http://localhost:3100/v1/actions/dcent_swap/get_quotes \
     "params": {
       "fromAsset": "eip155:1/slip44:60",
       "toAsset": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-      "amount": "1000000000000000"
+      "amount": "1000000000000000",
+      "fromDecimals": 18,
+      "toDecimals": 6
     }
   }'
 ```
@@ -199,6 +207,8 @@ curl -s -X POST 'http://localhost:3100/v1/actions/dcent_swap/dex_swap?dryRun=tru
       "toAsset": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "amount": "1000000000000000",
       "slippageBps": 100,
+      "fromDecimals": 18,
+      "toDecimals": 6,
       "toWalletAddress": "<SOLANA_WALLET_ADDRESS>"
     }
   }'
@@ -232,7 +242,9 @@ curl -s -X POST 'http://localhost:3100/v1/actions/dcent_swap/dex_swap?dryRun=tru
       "fromAsset": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501",
       "toAsset": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "amount": "10000000",
-      "slippageBps": 50
+      "slippageBps": 50,
+      "fromDecimals": 9,
+      "toDecimals": 6
     }
   }'
 ```

--- a/internal/objectives/issues/402-kamino-drift-rpc-url-missing.md
+++ b/internal/objectives/issues/402-kamino-drift-rpc-url-missing.md
@@ -1,0 +1,42 @@
+# 402: Kamino/Drift SDK RPC URL 미설정으로 Action 실행 전면 실패
+
+- **유형:** BUG
+- **심각도:** HIGH
+- **발견일:** 2026-03-19
+- **발견 경위:** DeFi UAT defi-08 (Kamino), defi-10 (Drift) dryRun 실행
+
+## 증상
+
+Kamino supply 또는 Drift add_margin action 실행 시:
+```
+ACTION_RESOLVE_FAILED: Endpoint URL must start with `http:` or `https:`.
+```
+
+## 원인
+
+Kamino SDK와 Drift SDK가 Solana RPC URL을 올바르게 전달받지 못함. #399에서 SDK 설치는 완료되었으나, SDK 초기화 시 RPC 엔드포인트 해석에 실패하는 것으로 추정.
+
+- `KaminoSdkWrapper`/`DriftSdkWrapper`가 RPC URL을 resolveRpcUrl 등에서 가져올 때 빈 문자열 또는 undefined가 전달되어 URL 파싱 에러 발생
+- #380 (PositionTracker RPC URL 미해결) 수정 시 Action Provider 쪽은 반영되지 않았을 가능성
+
+## 재현 조건
+
+```bash
+curl -s -X POST 'http://localhost:3100/v1/actions/kamino/kamino_supply?dryRun=true' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <session-token>' \
+  -d '{"walletId":"<SOL_WALLET>","network":"solana-mainnet","params":{"asset":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","humanAmount":"1.0","decimals":6}}'
+```
+
+동일 에러가 drift_perp/drift_add_margin에서도 발생.
+
+## 영향
+
+- Kamino Lending 전체 기능 사용 불가 (supply/withdraw)
+- Drift Perp 전체 기능 사용 불가 (add_margin/open_position/close_position/withdraw_margin)
+
+## 테스트 항목
+
+- [ ] Kamino kamino_supply dryRun 성공 (200 응답)
+- [ ] Drift drift_add_margin dryRun 성공 (200 응답)
+- [ ] 두 SDK가 Admin Settings의 RPC URL을 올바르게 수신하는지 단위 테스트

--- a/internal/objectives/issues/403-pendle-api-schema-regression.md
+++ b/internal/objectives/issues/403-pendle-api-schema-regression.md
@@ -1,0 +1,44 @@
+# 403: Pendle API 응답 스키마 불일치 재발 — buy_pt array vs object (#373/#398 3회차)
+
+- **유형:** BUG
+- **심각도:** HIGH
+- **발견일:** 2026-03-19
+- **발견 경위:** DeFi UAT defi-09 dryRun 실행
+
+## 증상
+
+Pendle buy_pt action 실행 시 Zod 스키마 검증 실패:
+```
+invalid_union: Expected array, received object
+```
+
+## 원인
+
+Pendle V2 API(`/v1/sdk/...`)의 응답 형식이 다시 변경된 것으로 추정. 이전 수정 이력:
+- #373 (v32.5): array → object 변경 대응
+- #398 (v32.10): 재발 대응
+
+3회째 동일 패턴 발생. Pendle API가 버전에 따라 응답 형식을 변경하거나, 마켓/토큰에 따라 다른 형식을 반환할 가능성.
+
+## 재현 조건
+
+```bash
+curl -s -X POST 'http://localhost:3100/v1/actions/pendle_yield/buy_pt?dryRun=true' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <session-token>' \
+  -d '{"walletId":"<EVM_WALLET>","network":"ethereum-mainnet","params":{"market":"0xcDD26Eb5EB2Ce0f203a84553853667fB73fab4dd","tokenIn":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48","amountIn":"5000000"}}'
+```
+
+## 제안 수정 방향
+
+Pendle API 응답을 `z.union([z.array(...), z.object({...})])` 양쪽 모두 허용하는 방식으로 변경하여 API 변동에 대한 내성 확보. 또는 Pendle API 버전을 명시적으로 고정.
+
+## 영향
+
+- Pendle Yield Trading 전체 기능 사용 불가 (buy_pt/redeem_pt)
+
+## 테스트 항목
+
+- [ ] Pendle buy_pt dryRun 성공 (200 응답)
+- [ ] Pendle API 응답이 array와 object 양쪽 모두 처리되는지 단위 테스트
+- [ ] 다양한 마켓/토큰 조합에서 응답 형식 일관성 확인

--- a/internal/objectives/issues/404-dcent-swap-decimals-required.md
+++ b/internal/objectives/issues/404-dcent-swap-decimals-required.md
@@ -1,0 +1,45 @@
+# 404: DCent Swap dex_swap에 fromDecimals/toDecimals 필수 파라미터 누락 시 검증 실패
+
+- **유형:** BUG
+- **심각도:** MEDIUM
+- **발견일:** 2026-03-19
+- **발견 경위:** DeFi UAT defi-12 dryRun 실행 — 시나리오대로 실행 시 실패, fromDecimals/toDecimals 추가 시 성공
+
+## 증상
+
+DCent Swap dex_swap action 실행 시 파라미터 검증 실패:
+```
+ACTION_VALIDATION_FAILED: fromDecimals: Required, toDecimals: Required
+```
+
+## 원인
+
+`dex_swap` 액션의 Zod 스키마에 `fromDecimals`(number)와 `toDecimals`(number)가 필수 필드로 정의되어 있으나:
+1. UAT 시나리오(defi-12)에 해당 필드가 포함되어 있지 않음
+2. CAIP-19 자산 식별자에서 decimals를 자동 추출하지 않고 명시적 전달을 요구
+
+## 재현 조건
+
+```bash
+# 실패 (fromDecimals/toDecimals 없음)
+curl -s -X POST 'http://localhost:3100/v1/actions/dcent_swap/dex_swap?dryRun=true' \
+  -d '{"walletId":"<WALLET>","network":"ethereum-mainnet","params":{"fromAsset":"eip155:1/slip44:60","toAsset":"eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48","amount":"1000000000000000","slippageBps":50}}'
+
+# 성공 (fromDecimals/toDecimals 추가)
+# ... + "fromDecimals": 18, "toDecimals": 6
+```
+
+## 제안 수정 방향
+
+1. **UAT 시나리오 업데이트**: defi-12의 모든 curl 예시에 `fromDecimals`/`toDecimals` 추가
+2. **(선택) DX 개선**: CAIP-19에서 네이티브 토큰(slip44:60→18, slip44:501→9)은 자동 추론, ERC-20은 토큰 레지스트리에서 조회하여 optional로 변경 검토
+
+## 영향
+
+- defi-12 UAT 시나리오가 그대로 실행하면 무조건 실패
+- 에이전트/SDK 사용자가 decimals를 직접 파악해야 하는 DX 마찰
+
+## 테스트 항목
+
+- [ ] defi-12 UAT 시나리오에 fromDecimals/toDecimals가 포함되어 있는지 확인
+- [ ] fromDecimals/toDecimals 없이 호출 시 명확한 에러 메시지 반환 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -49,6 +49,9 @@
 | 399 | BUG | HIGH | Kamino/Drift SDK 런타임 미설치로 Solana DeFi 기능 사용 불가 — #374/#375 후속 | — | FIXED | 2026-03-19 |
 | 400 | BUG | CRITICAL | Aave V3 포지션 formatWei 18 decimals 하드코딩으로 USDC 등 비-18 토큰 표시 오류 — amount/USD 0 표시 | — | FIXED | 2026-03-19 |
 | 401 | BUG | HIGH | PositionTracker 시작 시 STAKING 즉시 동기화 누락 — 최대 15분간 Lido 포지션 미표시 | — | FIXED | 2026-03-19 |
+| 402 | BUG | HIGH | Kamino/Drift SDK RPC URL 미설정으로 Action 실행 전면 실패 — Endpoint URL must start with http | — | FIXED | 2026-03-19 |
+| 403 | BUG | HIGH | Pendle API 응답 스키마 불일치 재발 — buy_pt array vs object (#373/#398 3회차) | — | FIXED | 2026-03-19 |
+| 404 | BUG | MEDIUM | DCent Swap dex_swap fromDecimals/toDecimals 필수인데 시나리오/문서 누락 — 파라미터 없이 호출 시 검증 실패 | — | FIXED | 2026-03-19 |
 
 ## Type Legend
 
@@ -61,7 +64,7 @@
 ## Summary
 
 - **OPEN:** 0
-- **FIXED:** 401
+- **FIXED:** 404
 - **WONTFIX:** 1
-- **Total:** 402
+- **Total:** 405
 - **Archived:** 366 (001–366)

--- a/internal/uat-reports/2026-03-19-defi-never-passed-v2.11.0-rc.25.md
+++ b/internal/uat-reports/2026-03-19-defi-never-passed-v2.11.0-rc.25.md
@@ -1,0 +1,118 @@
+# UAT Report: DeFi Never-Passed Scenarios — v2.11.0-rc.25
+
+- **Date**: 2026-03-19 17:30
+- **Version**: v2.11.0-rc.25 (commit: 5a1a3d8d)
+- **Category**: defi (never-passed retry)
+- **Network**: solana-mainnet, ethereum-mainnet
+- **Executor**: Claude Opus 4.6
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total | 6 |
+| Passed | 3 |
+| Failed | 3 |
+| Skipped | 0 |
+| Total Gas Cost | ~$0.08 |
+| New Issues Filed | 3 (#402, #403, #404) |
+
+## Results
+
+| # | ID | Title | dryRun | On-chain | Notes |
+|---|-----|-------|--------|----------|-------|
+| 1 | defi-01 | Jupiter Swap SOL→USDC | **PASS** | **CONFIRMED** | 0.005 SOL → 0.448 USDC, #396 fix verified |
+| 2 | defi-06 | Jito SOL Staking | **PASS** | **CONFIRMED** | 0.05 SOL → 0.0394 JitoSOL, DELAY 5min, #397 fix verified |
+| 3 | defi-08 | Kamino USDC Supply | **FAIL** | — | `Endpoint URL must start with http:` (#402) |
+| 4 | defi-09 | Pendle Yield PT Buy | **FAIL** | — | Zod array vs object (#403) |
+| 5 | defi-10 | Drift USDC Deposit | **FAIL** | — | `Endpoint URL must start with http:` (#402) |
+| 6 | defi-12 | DCent Swap ETH→USDC | **PASS** | **CONFIRMED** | 0.002 ETH → 4.311 USDC, #393 fix verified |
+
+## First-Time PASS Achieved
+
+3개 시나리오가 **최초 PASS** (dryRun + on-chain 모두 성공):
+- **defi-01**: Jupiter Swap — 기존 #396(프로그램 오류 6025) 수정 후 정상 동작
+- **defi-06**: Jito Staking — 기존 #397(manager fee account) 수정 후 정상 동작
+- **defi-12**: DCent Swap — 기존 #393(txdata.value) 수정 후 정상 동작. 단, `fromDecimals`/`toDecimals` 필수 (#404)
+
+## Transaction Log
+
+| Scenario | TX ID | TX Hash | Status | Network |
+|----------|-------|---------|--------|---------|
+| defi-01 | 019d055c...59c4 | b4e4oiKg...DXuRq | CONFIRMED | solana-mainnet |
+| defi-06 | 019d055c...c626 | 2q5z3qSC...pgsw | CONFIRMED | solana-mainnet |
+| defi-12 (retry) | 019d055d...413f | 0x7e3d66f0...a279 | CONFIRMED | ethereum-mainnet |
+
+## Balance Changes
+
+| Wallet | Asset | Before | After | Delta | Notes |
+|--------|-------|--------|-------|-------|-------|
+| Solana | SOL | 0.2999 | 0.2409 | -0.0591 | Jupiter swap + Jito stake + fees |
+| Solana | USDC | 10.000 | 10.448 | +0.448 | Jupiter swap output |
+| Solana | JitoSOL | 0 | 0.0394 | +0.0394 | Jito staking output |
+| EVM | ETH | 0.0172 | 0.0152 | -0.0020 | DCent swap + gas |
+| EVM | USDC | 23.127 | 27.438 | +4.311 | DCent swap output |
+
+## Failed Scenarios Detail
+
+### defi-08: Kamino USDC Supply
+- **Failed Step**: Step 3 (dryRun)
+- **Error**: `ACTION_RESOLVE_FAILED: Endpoint URL must start with http: or https:.`
+- **Root Cause**: Kamino SDK에 Solana RPC URL이 전달되지 않음
+- **Issue**: #402
+
+### defi-09: Pendle Yield PT Buy
+- **Failed Step**: Step 3 (dryRun)
+- **Error**: Zod validation — `Expected array, received object`
+- **Root Cause**: Pendle API 응답 형식 3회째 변경 (#373 → #398 → #403)
+- **Issue**: #403
+
+### defi-10: Drift USDC Deposit
+- **Failed Step**: Step 3 (dryRun)
+- **Error**: `ACTION_RESOLVE_FAILED: Endpoint URL must start with http: or https:.`
+- **Root Cause**: Drift SDK에 Solana RPC URL이 전달되지 않음 (Kamino와 동일 원인)
+- **Issue**: #402
+
+### defi-12: DCent Swap (첫 시도 실패)
+- **Error**: `DCent API returned empty txdata` (0.001 ETH 첫 시도)
+- **Resolution**: 0.002 ETH + slippageBps 100으로 재시도 시 성공
+- **Note**: 소액(0.001 ETH) 시 DCent API가 간헐적으로 빈 txdata 반환. 시나리오 최소 금액 상향 권장
+
+## Issues Registered
+
+| Issue ID | Type | Severity | Title |
+|----------|------|----------|-------|
+| #402 | BUG | HIGH | Kamino/Drift SDK RPC URL 미설정으로 Action 실행 전면 실패 |
+| #403 | BUG | HIGH | Pendle API 응답 스키마 불일치 재발 (3회차) |
+| #404 | BUG | MEDIUM | DCent Swap fromDecimals/toDecimals 필수인데 시나리오/문서 누락 |
+
+## Verification Checklist
+
+### defi-01: Jupiter Swap
+- [x] SOL 잔액 조회 성공 (200 응답)
+- [x] Jupiter 스왑 simulate 성공 (dryRun PASS)
+- [x] 실제 스왑 트랜잭션 생성 성공 (txId 반환)
+- [x] 트랜잭션 컨펌 완료 (CONFIRMED)
+- [x] 스왑 후 SOL 감소, USDC 증가 확인
+
+### defi-06: Jito Staking
+- [x] SOL 잔액 조회 성공 (200 응답)
+- [x] Jito 스테이킹 simulate 성공 (dryRun PASS)
+- [x] 실제 스테이킹 트랜잭션 생성 성공 (txId 반환)
+- [x] 트랜잭션 컨펌 완료 (CONFIRMED, DELAY 5min)
+- [x] 스테이킹 후 SOL 감소, JitoSOL 증가 확인
+
+### defi-12: DCent Swap
+- [x] ETH 잔액 조회 성공 (200 응답)
+- [x] DCent 스왑 dryRun 성공 (fromDecimals/toDecimals 추가 시)
+- [x] 실제 스왑 트랜잭션 생성 성공 (txId 반환, 0.002 ETH)
+- [x] 트랜잭션 컨펌 완료 (CONFIRMED)
+- [x] 스왑 후 ETH 감소, USDC 증가 확인
+
+## Environment
+
+- Daemon: localhost:3100
+- Solana Wallet: D4Y4...AtFA (solana-mainnet)
+- EVM Wallet: 0x1EB1...A37f (ethereum-mainnet)
+- OS: darwin (Darwin 25.3.0)
+- Node: v22.x

--- a/packages/actions/src/__tests__/dcent-provider-integration.test.ts
+++ b/packages/actions/src/__tests__/dcent-provider-integration.test.ts
@@ -333,4 +333,46 @@ describe('DcentSwapActionProvider resolve()', () => {
       ).rejects.toThrow();
     });
   });
+
+  describe('decimals auto-resolution (#404)', () => {
+    it('auto-resolves fromDecimals/toDecimals for well-known tokens', async () => {
+      const provider = createProvider();
+      // ETH=18, USDC=6 — both well-known in INTERMEDIATE_TOKENS
+      const result = await provider.resolve('dex_swap', {
+        fromAsset: ETH_CAIP19,
+        toAsset: USDC_CAIP19,
+        amount: '1000000000000000000',
+        // No fromDecimals/toDecimals provided
+      }, CONTEXT);
+
+      const requests = Array.isArray(result) ? result : [result];
+      expect(requests.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('throws clear error for unknown asset without explicit decimals', async () => {
+      const provider = createProvider();
+      await expect(
+        provider.resolve('dex_swap', {
+          fromAsset: 'eip155:1/erc20:0x0000000000000000000000000000000000099999',
+          toAsset: USDC_CAIP19,
+          amount: '1000',
+          // No fromDecimals — unknown token
+        }, CONTEXT),
+      ).rejects.toThrow('fromDecimals');
+    });
+
+    it('accepts explicit decimals even for known tokens', async () => {
+      const provider = createProvider();
+      const result = await provider.resolve('dex_swap', {
+        fromAsset: ETH_CAIP19,
+        toAsset: USDC_CAIP19,
+        amount: '1000000000000000000',
+        fromDecimals: 18,
+        toDecimals: 6,
+      }, CONTEXT);
+
+      const requests = Array.isArray(result) ? result : [result];
+      expect(requests.length).toBeGreaterThanOrEqual(1);
+    });
+  });
 });

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -278,12 +278,14 @@ export function registerBuiltInProviders(
       key: 'kamino',
       enabledKey: 'actions.kamino_enabled',
       factory: () => {
+        const kaminoRpcUrl = settingsReader.get('rpc.solana_mainnet') || '';
         const config: KaminoConfig = {
           enabled: true,
           market: settingsReader.get('actions.kamino_market') || 'main',
           hfThreshold: Number(settingsReader.get('actions.kamino_hf_threshold')) || 1.2,
+          rpcUrl: kaminoRpcUrl,
         };
-        return new KaminoLendingProvider(config, new KaminoSdkWrapper(''));
+        return new KaminoLendingProvider(config, new KaminoSdkWrapper(kaminoRpcUrl));
       },
     },
     {
@@ -305,11 +307,13 @@ export function registerBuiltInProviders(
       key: 'drift_perp',
       enabledKey: 'actions.drift_enabled',
       factory: () => {
+        const driftRpcUrl = settingsReader.get('rpc.solana_mainnet') || '';
         const config: DriftConfig = {
           enabled: true,
           subAccount: 0,
+          rpcUrl: driftRpcUrl,
         };
-        return new DriftPerpProvider(config, new DriftSdkWrapper('', config.subAccount));
+        return new DriftPerpProvider(config, new DriftSdkWrapper(driftRpcUrl, config.subAccount));
       },
     },
     {

--- a/packages/actions/src/providers/dcent-swap/index.ts
+++ b/packages/actions/src/providers/dcent-swap/index.ts
@@ -21,7 +21,7 @@ import type {
 import { DcentSwapApiClient } from './dcent-api-client.js';
 import { type DcentSwapConfig, DCENT_SWAP_DEFAULTS } from './config.js';
 import { getDcentQuotes, executeDexSwap, type DcentQuoteResult, type GetQuotesParams } from './dex-swap.js';
-import { findTwoHopRoutes, executeTwoHopSwap, type TwoHopQuoteResult } from './auto-router.js';
+import { findTwoHopRoutes, executeTwoHopSwap, INTERMEDIATE_TOKENS, type TwoHopQuoteResult } from './auto-router.js';
 import { resolveProviderHumanAmount } from '../../common/resolve-human-amount.js';
 
 // ---------------------------------------------------------------------------
@@ -36,8 +36,10 @@ const GetQuotesInputSchema = z.object({
     .describe('Human-readable amount (e.g., "1.5" for 1.5 tokens). Requires decimals field. Mutually exclusive with amount.'),
   decimals: z.number().int().min(0).max(24).optional()
     .describe('Token decimals for humanAmount conversion. Required when using humanAmount.'),
-  fromDecimals: z.number().int().min(0).max(18),
-  toDecimals: z.number().int().min(0).max(18),
+  fromDecimals: z.number().int().min(0).max(18).optional()
+    .describe('Source token decimals. Auto-resolved from well-known tokens when omitted.'),
+  toDecimals: z.number().int().min(0).max(18).optional()
+    .describe('Destination token decimals. Auto-resolved from well-known tokens when omitted.'),
 });
 
 const DexSwapInputSchema = z.object({
@@ -48,15 +50,37 @@ const DexSwapInputSchema = z.object({
     .describe('Human-readable amount (e.g., "1.5" for 1.5 tokens). Requires decimals field. Mutually exclusive with amount.'),
   decimals: z.number().int().min(0).max(24).optional()
     .describe('Token decimals for humanAmount conversion. Required when using humanAmount. Note: this is separate from fromDecimals/toDecimals.'),
-  fromDecimals: z.number().int().min(0).max(18),
-  toDecimals: z.number().int().min(0).max(18),
+  fromDecimals: z.number().int().min(0).max(18).optional()
+    .describe('Source token decimals. Auto-resolved from well-known tokens when omitted.'),
+  toDecimals: z.number().int().min(0).max(18).optional()
+    .describe('Destination token decimals. Auto-resolved from well-known tokens when omitted.'),
   providerId: z.string().optional(),
   slippageBps: z.number().int().optional(),
 });
 
 // ---------------------------------------------------------------------------
-// Helper
+// Helpers
 // ---------------------------------------------------------------------------
+
+/** Build flat CAIP-19 → decimals lookup from INTERMEDIATE_TOKENS. */
+const KNOWN_DECIMALS: Map<string, number> = new Map();
+for (const tokens of Object.values(INTERMEDIATE_TOKENS)) {
+  for (const t of tokens) {
+    KNOWN_DECIMALS.set(t.caip19.toLowerCase(), t.decimals);
+  }
+}
+
+/**
+ * Resolve token decimals from CAIP-19 asset ID.
+ * Uses well-known tokens from INTERMEDIATE_TOKENS map.
+ */
+function resolveDecimals(caip19: string, label: string): number {
+  const d = KNOWN_DECIMALS.get(caip19.toLowerCase());
+  if (d !== undefined) return d;
+  throw new ChainError('INVALID_INSTRUCTION', 'ethereum', {
+    message: `${label} is required for asset ${caip19} — not a well-known token. Provide ${label} explicitly (e.g., 18 for ETH, 6 for USDC).`,
+  });
+}
 
 /** Check if a ChainError indicates no swap route available. */
 function isNoRouteError(err: ChainError): boolean {
@@ -128,7 +152,9 @@ export class DcentSwapActionProvider implements IActionProvider {
         // DS-07: get_quotes is informational. Use queryQuotes() for direct access.
         const input = GetQuotesInputSchema.parse(rp);
         if (!input.amount) throw new ChainError('INVALID_INSTRUCTION', context.chain, { message: 'Either amount or humanAmount (with decimals) is required' });
-        const result = await getDcentQuotes(this.getClient(), { ...input, fromWalletAddress: context.walletAddress } as GetQuotesParams);
+        const fromDec = input.fromDecimals ?? resolveDecimals(input.fromAsset, 'fromDecimals');
+        const toDec = input.toDecimals ?? resolveDecimals(input.toAsset, 'toDecimals');
+        const result = await getDcentQuotes(this.getClient(), { ...input, fromDecimals: fromDec, toDecimals: toDec, fromWalletAddress: context.walletAddress } as GetQuotesParams);
         throw new ChainError('INVALID_INSTRUCTION', context.chain, {
           message: `get_quotes is informational. Use queryQuotes() query method. Result: ${JSON.stringify({
             dexProviders: result.dexProviders.length,
@@ -140,7 +166,9 @@ export class DcentSwapActionProvider implements IActionProvider {
       case 'dex_swap': {
         const input = DexSwapInputSchema.parse(rp);
         if (!input.amount) throw new ChainError('INVALID_INSTRUCTION', context.chain, { message: 'Either amount or humanAmount (with decimals) is required' });
-        const swapParams = { fromAsset: input.fromAsset, toAsset: input.toAsset, amount: input.amount, fromDecimals: input.fromDecimals, toDecimals: input.toDecimals, walletAddress: context.walletAddress, providerId: input.providerId, slippageBps: input.slippageBps };
+        const swapFromDec = input.fromDecimals ?? resolveDecimals(input.fromAsset, 'fromDecimals');
+        const swapToDec = input.toDecimals ?? resolveDecimals(input.toAsset, 'toDecimals');
+        const swapParams = { fromAsset: input.fromAsset, toAsset: input.toAsset, amount: input.amount, fromDecimals: swapFromDec, toDecimals: swapToDec, walletAddress: context.walletAddress, providerId: input.providerId, slippageBps: input.slippageBps };
         try {
           return await executeDexSwap(
             this.getClient(),

--- a/packages/actions/src/providers/drift/config.ts
+++ b/packages/actions/src/providers/drift/config.ts
@@ -13,6 +13,8 @@ export interface DriftConfig {
   enabled: boolean;
   /** Sub-account index (default 0, DEC-PERP-15). */
   subAccount: number;
+  /** Solana RPC URL for SDK calls. */
+  rpcUrl?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/actions/src/providers/kamino/config.ts
+++ b/packages/actions/src/providers/kamino/config.ts
@@ -15,6 +15,8 @@ export interface KaminoConfig {
   market: string;
   /** Health factor warning threshold. Default 1.2. */
   hfThreshold: number;
+  /** Solana RPC URL for SDK calls. */
+  rpcUrl?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/actions/src/providers/pendle/__tests__/pendle-api-client.test.ts
+++ b/packages/actions/src/providers/pendle/__tests__/pendle-api-client.test.ts
@@ -207,6 +207,26 @@ describe('PendleApiClient', () => {
       expect(result.tx.value).toBe('0');
       expect(result.amountOut).toBe('1000000000000000000');
     });
+
+    it('normalizes array response to single object (#403)', async () => {
+      server.use(
+        http.get(`${BASE_URL}/v2/sdk/1/convert`, () => {
+          return HttpResponse.json([CONVERT_RESPONSE]);
+        }),
+      );
+
+      const client = new PendleApiClient(makeConfig(), 1);
+      const result = await client.convert({
+        tokensIn: '0xA',
+        amountsIn: '100',
+        tokensOut: '0xB',
+        slippage: '0.01',
+        receiver: '0xC',
+      });
+
+      expect(result.tx.to).toBe('0xPendleRouter');
+      expect(result.amountOut).toBe('1000000000000000000');
+    });
   });
 
   describe('getSwappingPrices', () => {

--- a/packages/actions/src/providers/pendle/pendle-api-client.ts
+++ b/packages/actions/src/providers/pendle/pendle-api-client.ts
@@ -59,13 +59,15 @@ export class PendleApiClient extends ActionApiClient {
     slippage: string;
     receiver: string;
   }): Promise<PendleConvertResponse> {
-    return this.get(`v2/sdk/${this.chainId}/convert`, PendleConvertResponseSchema, {
+    const raw = await this.get(`v2/sdk/${this.chainId}/convert`, PendleConvertResponseSchema, {
       tokensIn: params.tokensIn,
       amountsIn: params.amountsIn,
       tokensOut: params.tokensOut,
       slippage: params.slippage,
       receiver: params.receiver,
     });
+    // Normalize: Pendle API alternates between object and array responses
+    return Array.isArray(raw) ? raw[0]! : raw;
   }
 
   /**

--- a/packages/actions/src/providers/pendle/schemas.ts
+++ b/packages/actions/src/providers/pendle/schemas.ts
@@ -57,7 +57,7 @@ export type PendleMarketsResponse = z.infer<typeof PendleMarketsResponseSchema>;
 // Convert Response (/v2/sdk/{chainId}/convert) — unified for all actions
 // ---------------------------------------------------------------------------
 
-export const PendleConvertResponseSchema = z.object({
+const PendleConvertObjectSchema = z.object({
   tx: z.object({
     to: z.string(),
     data: z.string().describe('hex-encoded calldata'),
@@ -66,7 +66,13 @@ export const PendleConvertResponseSchema = z.object({
   amountOut: z.string(),
 }).passthrough();
 
-export type PendleConvertResponse = z.infer<typeof PendleConvertResponseSchema>;
+/** Accept both object and single-element array — Pendle API alternates formats across versions. */
+export const PendleConvertResponseSchema = z.union([
+  PendleConvertObjectSchema,
+  z.array(PendleConvertObjectSchema).min(1),
+]);
+
+export type PendleConvertResponse = z.infer<typeof PendleConvertObjectSchema>;
 
 // ---------------------------------------------------------------------------
 // Swapping Prices (/v1/sdk/{chainId}/markets/{market}/swapping-prices)


### PR DESCRIPTION
## Summary
- **#402**: Pass `rpc.solana_mainnet` from Admin Settings to KaminoSdkWrapper and DriftSdkWrapper (was empty string `''`)
- **#403**: Accept both object and array responses from Pendle convert API via `z.union` — 3rd occurrence of this API format change
- **#404**: Make `fromDecimals`/`toDecimals` optional in DCent Swap, auto-resolve from well-known INTERMEDIATE_TOKENS map

## Test plan
- [x] Pendle API client test: array response normalization (#403)
- [x] DCent provider test: auto-resolution of decimals for well-known tokens (#404)
- [x] DCent provider test: clear error for unknown tokens without explicit decimals
- [x] All 116 related tests pass (5 test files)
- [x] Typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)