### PR TITLE
fix(daemon): fix #461 admin test sign request base64 format bug

### DIFF
--- a/internal/objectives/issues/461-admin-test-sign-request-base64-format.md
+++ b/internal/objectives/issues/461-admin-test-sign-request-base64-format.md
@@ -2,7 +2,7 @@
 
 - **유형:** BUG
 - **심각도:** HIGH
-- **상태:** OPEN
+- **상태:** FIXED
 - **등록일:** 2026-03-26
 - **관련 이슈:** #456 (Push Relay 서명 요청 payload 포맷 불일치)
 - **발견 경위:** Push Relay 디버그 로그에서 Admin 테스트 서명 요청의 `request` 필드가 base64 blob으로 전송되는 것 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -46,7 +46,7 @@
 | 458 | ENHANCEMENT | MEDIUM | Push Relay 디버그 모드에서 푸시 payload 및 서명 응답 내용 미로그 | — | FIXED | 2026-03-25 |
 | 459 | ENHANCEMENT | MEDIUM | 세션 토큰으로 GET /v1/wallets, GET /v1/wallets/:id 조회 불가 (masterAuth only) | — | FIXED | 2026-03-25 |
 | 460 | BUG | HIGH | Push Relay config.toml static_fields가 푸시 payload에 반영되지 않음 | — | FIXED | 2026-03-25 |
-| 461 | BUG | HIGH | Admin UI 테스트 서명 요청이 여전히 base64 래핑 포맷으로 전송됨 (#456 수정 누락) | — | OPEN | 2026-03-26 |
+| 461 | BUG | HIGH | Admin UI 테스트 서명 요청이 여전히 base64 래핑 포맷으로 전송됨 (#456 수정 누락) | — | FIXED | 2026-03-26 |
 
 ## Type Legend
 
@@ -58,9 +58,9 @@
 
 ## Summary
 
-- **OPEN:** 1
+- **OPEN:** 0
 - **PLANNED:** 1
-- **FIXED:** 459
+- **FIXED:** 460
 - **WONTFIX:** 1
 - **Total:** 462
 - **Archived:** 428 (001–428)

--- a/packages/daemon/src/__tests__/push-relay-signing-channel.test.ts
+++ b/packages/daemon/src/__tests__/push-relay-signing-channel.test.ts
@@ -18,7 +18,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { SignRequest, SignResponse } from '@waiaas/core';
-import { PushRelaySigningChannel } from '../services/signing-sdk/channels/push-relay-signing-channel.js';
+import { PushRelaySigningChannel, buildSignRequestPushPayload } from '../services/signing-sdk/channels/push-relay-signing-channel.js';
 
 // ---------------------------------------------------------------------------
 // Mock fetch
@@ -517,6 +517,67 @@ describe('PushRelaySigningChannel', () => {
   // -----------------------------------------------------------------------
   // Test 11: POST non-2xx status logs error without throwing
   // -----------------------------------------------------------------------
+
+  // -----------------------------------------------------------------------
+  // Test: buildSignRequestPushPayload produces flat fields (no base64)
+  // -----------------------------------------------------------------------
+
+  it('buildSignRequestPushPayload returns flat fields without base64 encoding', () => {
+    const input = {
+      version: '1',
+      requestId: 'req-123',
+      caip2ChainId: 'eip155:1',
+      networkName: 'ethereum-mainnet',
+      signerAddress: '0xabc',
+      message: 'Sign this',
+      displayMessage: 'Transfer 1 ETH',
+      expiresAt: '2026-03-26T12:00:00Z',
+      metadata: { txId: 'tx-1', type: 'TRANSFER' },
+      responseChannel: { type: 'push_relay', pushRelayUrl: 'https://relay.example.com' },
+    };
+
+    const payload = buildSignRequestPushPayload(input, { title: 'Test Title', universalLinkUrl: 'https://link.example.com' });
+
+    // Flat string fields
+    expect(payload.title).toBe('Test Title');
+    expect(payload.body).toBe('Transfer 1 ETH');
+    expect(payload.version).toBe('1');
+    expect(payload.requestId).toBe('req-123');
+    expect(payload.caip2ChainId).toBe('eip155:1');
+    expect(payload.networkName).toBe('ethereum-mainnet');
+    expect(payload.signerAddress).toBe('0xabc');
+    expect(payload.message).toBe('Sign this');
+    expect(payload.displayMessage).toBe('Transfer 1 ETH');
+    expect(payload.expiresAt).toBe('2026-03-26T12:00:00Z');
+    expect(payload.universalLinkUrl).toBe('https://link.example.com');
+
+    // metadata/responseChannel are JSON-stringified
+    expect(JSON.parse(payload.metadata)).toEqual({ txId: 'tx-1', type: 'TRANSFER' });
+    expect(JSON.parse(payload.responseChannel)).toEqual({ type: 'push_relay', pushRelayUrl: 'https://relay.example.com' });
+
+    // No base64-encoded 'request' field
+    expect(payload).not.toHaveProperty('request');
+  });
+
+  it('buildSignRequestPushPayload omits optional fields when absent', () => {
+    const input = {
+      version: '1',
+      requestId: 'req-456',
+      signerAddress: '0xdef',
+      message: 'Sign this',
+      displayMessage: 'Approve',
+      expiresAt: '2026-03-26T12:00:00Z',
+      metadata: {},
+      responseChannel: { type: 'push_relay' },
+    };
+
+    const payload = buildSignRequestPushPayload(input);
+
+    expect(payload.title).toBe('WAIaaS Sign Request'); // default title
+    expect(payload).not.toHaveProperty('caip2ChainId');
+    expect(payload).not.toHaveProperty('networkName');
+    expect(payload).not.toHaveProperty('universalLinkUrl');
+  });
 
   it('POST non-2xx logs error without throwing', async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });

--- a/packages/daemon/src/api/routes/wallet-apps.ts
+++ b/packages/daemon/src/api/routes/wallet-apps.ts
@@ -14,6 +14,7 @@ import { WAIaaSError, SignResponseSchema } from '@waiaas/core';
 import { generateId } from '../../infrastructure/database/id.js';
 import type { WalletAppService, WalletApp, WalletAppWithUsedBy } from '../../services/signing-sdk/wallet-app-service.js';
 import type { SettingsService } from '../../infrastructure/settings/settings-service.js';
+import { buildSignRequestPushPayload } from '../../services/signing-sdk/channels/index.js';
 import {
   WalletAppListResponseSchema,
   WalletAppCreateRequestSchema,
@@ -366,8 +367,23 @@ export function createWalletAppsRoutes(deps: WalletAppsRouteDeps): OpenAPIHono {
         expiresAt: expiresAt.toISOString(),
       };
 
-      const encoded = Buffer.from(JSON.stringify(testRequest), 'utf-8').toString('base64url');
       const pushRelayUrl = app.pushRelayUrl.replace(/\/$/, '');
+
+      // Build flat-field payload (same format as PushRelaySigningChannel)
+      const payload = buildSignRequestPushPayload(
+        {
+          version: testRequest.version,
+          requestId: testRequest.requestId,
+          caip2ChainId: testRequest.chainId,
+          signerAddress: testRequest.signerAddress,
+          message: testRequest.message,
+          displayMessage: testRequest.displayMessage,
+          expiresAt: testRequest.expiresAt,
+          metadata: testRequest.metadata,
+          responseChannel: testRequest.responseChannel,
+        },
+        { title: 'WAIaaS Test Sign Request' },
+      );
 
       // Send sign request to Push Relay
       const pushRes = await fetch(`${pushRelayUrl}/v1/push`, {
@@ -376,11 +392,7 @@ export function createWalletAppsRoutes(deps: WalletAppsRouteDeps): OpenAPIHono {
         body: JSON.stringify({
           subscriptionToken: app.subscriptionToken,
           category: 'sign_request',
-          payload: {
-            title: 'WAIaaS Test Sign Request',
-            body: `Test sign request for ${app.displayName}`,
-            request: encoded,
-          },
+          payload,
         }),
       });
       if (!pushRes.ok) {

--- a/packages/daemon/src/services/signing-sdk/channels/index.ts
+++ b/packages/daemon/src/services/signing-sdk/channels/index.ts
@@ -4,11 +4,12 @@
  * @see internal/design/73-signing-protocol-v1.md
  */
 
-export { PushRelaySigningChannel } from './push-relay-signing-channel.js';
+export { PushRelaySigningChannel, buildSignRequestPushPayload } from './push-relay-signing-channel.js';
 export type {
   PushRelaySigningChannelOpts,
   SendRequestParams,
   SendRequestResult,
+  SignRequestPayloadInput,
 } from './push-relay-signing-channel.js';
 
 export { TelegramSigningChannel } from './telegram-signing-channel.js';

--- a/packages/daemon/src/services/signing-sdk/channels/push-relay-signing-channel.ts
+++ b/packages/daemon/src/services/signing-sdk/channels/push-relay-signing-channel.ts
@@ -55,6 +55,52 @@ export interface SendRequestResult {
 }
 
 // ---------------------------------------------------------------------------
+// Shared payload builder (also used by admin test-sign-request endpoint)
+// ---------------------------------------------------------------------------
+
+export interface SignRequestPayloadInput {
+  version: string;
+  requestId: string;
+  caip2ChainId?: string;
+  networkName?: string;
+  signerAddress: string;
+  message: string;
+  displayMessage: string;
+  expiresAt: string;
+  metadata: Record<string, unknown>;
+  responseChannel: Record<string, unknown>;
+}
+
+/**
+ * Build a flat-field push payload for Push Relay.
+ * D'CENT expects individual top-level fields — NOT a base64-encoded blob.
+ *
+ * @see internal/objectives/issues/456-push-relay-flat-payload.md
+ * @see internal/objectives/issues/461-admin-test-sign-request-base64-format.md
+ */
+export function buildSignRequestPushPayload(
+  request: SignRequestPayloadInput,
+  opts?: { title?: string; universalLinkUrl?: string },
+): Record<string, string> {
+  const payload: Record<string, string> = {
+    title: opts?.title ?? 'WAIaaS Sign Request',
+    body: request.displayMessage,
+    version: request.version,
+    requestId: request.requestId,
+    signerAddress: request.signerAddress,
+    message: request.message,
+    displayMessage: request.displayMessage,
+    expiresAt: request.expiresAt,
+    metadata: JSON.stringify(request.metadata),
+    responseChannel: JSON.stringify(request.responseChannel),
+  };
+  if (request.caip2ChainId) payload.caip2ChainId = request.caip2ChainId;
+  if (request.networkName) payload.networkName = request.networkName;
+  if (opts?.universalLinkUrl) payload.universalLinkUrl = opts.universalLinkUrl;
+  return payload;
+}
+
+// ---------------------------------------------------------------------------
 // PushRelaySigningChannel
 // ---------------------------------------------------------------------------
 
@@ -108,21 +154,7 @@ export class PushRelaySigningChannel {
             body: JSON.stringify({
               subscriptionToken: requestTopic,
               category: 'sign_request',
-              payload: {
-                title: 'WAIaaS Sign Request',
-                body: request.displayMessage,
-                version: request.version,
-                requestId: request.requestId,
-                caip2ChainId: request.caip2ChainId,
-                networkName: request.networkName,
-                signerAddress: request.signerAddress,
-                message: request.message,
-                displayMessage: request.displayMessage,
-                expiresAt: request.expiresAt,
-                metadata: JSON.stringify(request.metadata),
-                responseChannel: JSON.stringify(request.responseChannel),
-                universalLinkUrl,
-              },
+              payload: buildSignRequestPushPayload(request, { universalLinkUrl }),
             }),
             signal: controller.signal,
           });


### PR DESCRIPTION
## Summary
- Extract shared `buildSignRequestPushPayload()` helper from `PushRelaySigningChannel` to eliminate duplicated payload construction logic
- Fix admin test sign request endpoint (`wallet-apps.ts`) to send flat fields instead of base64-wrapped blob — D'CENT can now parse the payload correctly
- Add 2 unit tests for the shared helper (flat field verification, optional field omission)

## Test plan
- [x] `buildSignRequestPushPayload` unit tests pass (flat fields, no `request` blob)
- [x] `PushRelaySigningChannel` existing 11 tests still pass
- [x] Typecheck passes
- [x] E2E verified: daemon → Push Relay debug log shows flat payload, Pushwoosh sent=1

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)