### PR TITLE
fix(desktop): strip createRequire in SEA bundle + Module._load intercept (issue 494)

### DIFF
--- a/internal/objectives/issues/494-desktop-sea-createRequire-bypass-shim.md
+++ b/internal/objectives/issues/494-desktop-sea-createRequire-bypass-shim.md
@@ -1,0 +1,62 @@
+# 494 — SEA shim의 sodium-native intercept가 createRequire 경유 호출을 잡지 못함
+
+- **유형:** BUG
+- **심각도:** CRITICAL
+- **상태:** FIXED
+- **발견일:** 2026-04-10
+- **발견 경위:** v2.14.1-rc.3 DMG에서 여전히 "Cannot find module 'sodium-native'" 에러. 이슈 493 수정(natives['sodium-native'] 추가)이 main에 반영되었으나 실제 DMG에서 동작하지 않음.
+
+## 원인
+
+이슈 493에서 추가한 intercept:
+```js
+natives['sodium-native'] = addons['sodium-native.node'];
+```
+
+이 값은 `globalThis.__waiaasSeaRequire` 함수의 lookup 맵에 들어가고, shim이 번들 CJS wrapper의 `require` 파라미터를 shadow:
+```js
+var require = globalThis.__waiaasSeaRequire || require;
+```
+
+하지만 daemon 소스 4곳은 `createRequire(import.meta.url)` 로 **독립적인 require 함수를 생성**:
+```ts
+const require = createRequire(import.meta.url);
+sodium = require('sodium-native') as SodiumNative;
+```
+
+`createRequire()`는 `Module.createRequire()`의 결과로, Node.js 내부의 `Module._load` 를 거치는 별도 CJS 로더입니다. 이 로더는 우리 shim의 `__waiaasSeaRequire`와 **완전히 분리**된 코드 경로이므로 `natives` 맵 lookup에 도달하지 않습니다.
+
+결과: `createRequire(process.execPath)('sodium-native')` → `Module._resolveFilename` → 디스크에서 `sodium-native` 패키지 검색 → SEA 바이너리 옆에 없음 → MODULE_NOT_FOUND.
+
+## 수정 방향
+
+`Module._load` 를 전역으로 패치하여 **모든 require 코드 경로** (외부 파라미터 shadow + createRequire + 기타)에서 네이티브 모듈 이름을 intercept:
+
+```js
+var origLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (Object.prototype.hasOwnProperty.call(natives, request)) return natives[request];
+  return origLoad.call(this, request, parent, isMain);
+};
+```
+
+이렇게 하면:
+- esbuild 번들 내부의 `require('sodium-native')` → shim shadow require → natives lookup ✓ (기존)
+- esbuild 번들 내부의 `require('require-addon')` → shim shadow require → natives lookup ✓ (기존)
+- `createRequire(...)('sodium-native')` → Module._load → natives lookup ✓ (**신규**)
+- 기타 동적 require 경로 → Module._load → natives lookup ✓ (**신규**)
+
+기존 `globalThis.__waiaasSeaRequire` 와 `var require = ...` shadow는 유지 (esbuild embedderRequire fallback 대응).
+
+## 테스트 항목
+
+- [ ] **로컬 SEA 바이너리**: `POST /v1/wallets` 3개 체인 모두 성공
+- [ ] **로컬 Tauri .app 빌드**: 실행 → Step 2 Create Wallets 에러 없이 완료
+- [ ] `.app`의 사이드카 데몬에서 실제 `/v1/wallets` POST 호출이 200 반환
+- [ ] CI stage1 + stage2 통과
+- [ ] RC DMG clean-install 검증 후 릴리스
+
+## 관련 이슈
+
+- **493** — 이전 수정 시도. natives 맵에 추가했으나 createRequire 경로는 미해결.
+- **486** — SEA bootstrap shim 원본 설계.

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -38,6 +38,7 @@
 | 491 | BUG | HIGH | Desktop Setup Wizard가 bootstrap recovery.key와 충돌해 master password 설정 불가 | — | FIXED | 2026-04-09 |
 | 492 | BUG | HIGH | Desktop Setup Wizard: 지갑 생성 auth 누락 + 체인 목록 불완전 | — | FIXED | 2026-04-09 |
 | 493 | BUG | CRITICAL | SEA 데몬에서 sodium-native 직접 require가 지갑 생성 시 MODULE_NOT_FOUND | — | FIXED | 2026-04-09 |
+| 494 | BUG | CRITICAL | SEA shim의 sodium-native intercept가 createRequire 경유 호출을 잡지 못함 | — | FIXED | 2026-04-10 |
 
 ## Type Legend
 
@@ -51,7 +52,7 @@
 
 - **OPEN:** 0
 - **PLANNED:** 0
-- **FIXED:** 485
+- **FIXED:** 486
 - **WONTFIX:** 1
-- **Total:** 488
+- **Total:** 489
 - **Archived:** 468 (001–468)

--- a/packages/daemon/scripts/build-sea.mjs
+++ b/packages/daemon/scripts/build-sea.mjs
@@ -273,6 +273,17 @@ async function main() {
   // no direct requires exist today so we only add sodium-native for now.
   natives['sodium-native'] = addons['sodium-native.node'];
 
+  // Issue 494: patch Module._load globally so ALL require code paths
+  // (including createRequire-generated loaders) hit our native map. The
+  // per-wrapper \`var require = __waiaasSeaRequire\` shadow only covers
+  // the outer CJS wrapper parameter; createRequire() creates an independent
+  // loader that goes through Module._load instead.
+  var origLoad = Module._load;
+  Module._load = function __waiaasModuleLoad(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(natives, request)) return natives[request];
+    return origLoad.call(this, request, parent, isMain);
+  };
+
   var diskRequire;
   try { diskRequire = Module.createRequire(process.execPath); } catch (_) {}
 
@@ -289,20 +300,30 @@ var require = globalThis.__waiaasSeaRequire || require;
 // === end SEA bootstrap shim ===
 `;
 
-  // esbuild plugin: inline relative `require('*/package.json')` at build time.
-  // Several files use `const require = createRequire(import.meta.url);` + a
-  // dynamic require to read the package version. In SEA that runtime require
-  // fails because process.execPath has no sibling package.json. Rewrite the
-  // source text so the literal version object is inlined.
-  const inlinePackageJsonPlugin = {
-    name: 'inline-package-json',
+  // esbuild plugin: SEA source compatibility transforms (issues 486, 492, 494).
+  //
+  // Several daemon/CLI source files use `createRequire(import.meta.url)` to get
+  // a CJS `require` function in ESM context. This creates a SEPARATE loader
+  // that resolves from disk relative to process.execPath — completely bypassing
+  // both esbuild's bundling and our SEA bootstrap shim. In SEA mode these calls
+  // fail with MODULE_NOT_FOUND because there's no node_modules next to the
+  // binary.
+  //
+  // Fix: strip the createRequire pattern at build time so that:
+  //   `const require = createRequire(import.meta.url)` → removed
+  //     → subsequent `require('sodium-native')` uses the outer CJS require
+  //     → esbuild statically resolves and bundles it (or externalizes it)
+  //   `const esmRequire = createRequire(import.meta.url)` → `const esmRequire = require`
+  //     → aliased to outer CJS require for existing `esmRequire(...)` call sites
+  //   `import { createRequire } from 'node:module'` → removed (unused after above)
+  //
+  // Also inlines relative `require('*/package.json')` as literal JSON objects
+  // since those resolve relative to source location, not the SEA binary.
+  const seaSourcePlugin = {
+    name: 'sea-source-compat',
     setup(build) {
       const pkgCache = new Map();
-      // Match .ts (cli entrypoint source) and .js (daemon compiled dist/).
-      // The @waiaas/daemon package is consumed via its `main: dist/index.js`
-      // so esbuild reads compiled JS where the pattern survives.
       build.onLoad({ filter: /\.(ts|js)$/ }, (args) => {
-        // Skip node_modules to avoid touching third-party code
         if (args.path.includes('/node_modules/')) return null;
         let source;
         try {
@@ -310,12 +331,34 @@ var require = globalThis.__waiaasSeaRequire || require;
         } catch {
           return null;
         }
-        // Match require(...) and any createRequire-alias identifier like
-        // esmRequire(...) that reads a relative package.json.
-        if (!/\b(?:require|esmRequire)\(['"][^'"]*package\.json['"]\)/.test(source)) {
-          return null;
-        }
-        const rewritten = source.replace(
+
+        // Quick bail: file has no createRequire or package.json patterns
+        if (!/createRequire|package\.json/.test(source)) return null;
+
+        let modified = source;
+
+        // 1. Strip `const require = createRequire(import.meta.url);`
+        //    This lets the outer CJS require take over, enabling esbuild to
+        //    statically resolve require('sodium-native'), require('ripple-keypairs') etc.
+        modified = modified.replace(
+          /(?:const|let|var)\s+require\s*=\s*createRequire\([^)]*\);?\s*\n?/g,
+          '/* [SEA] createRequire stripped — using outer CJS require */\n',
+        );
+
+        // 2. Alias `const esmRequire = createRequire(...)` → `const esmRequire = require`
+        modified = modified.replace(
+          /(?:const|let|var)\s+(esmRequire|require_)\s*=\s*createRequire\([^)]*\);?/g,
+          'const $1 = require; /* [SEA] aliased to outer CJS require */',
+        );
+
+        // 3. Strip the now-unused createRequire import
+        modified = modified.replace(
+          /import\s*\{\s*createRequire\s*\}\s*from\s*['"]node:module['"];?\s*\n?/g,
+          '/* [SEA] createRequire import stripped */\n',
+        );
+
+        // 4. Inline relative package.json requires (unchanged from original plugin)
+        modified = modified.replace(
           /\b(?:require|esmRequire)\((['"])([^'"]*package\.json)\1\)/g,
           (match, _quote, relPath) => {
             const absPath = resolve(dirname(args.path), relPath);
@@ -329,14 +372,13 @@ var require = globalThis.__waiaasSeaRequire || require;
               }
               pkgCache.set(absPath, pkg);
             }
-            // Keep only fields actually consumed by callers (version field is
-            // the only one used across all 6 call sites in daemon + cli).
             return JSON.stringify({ version: pkg.version ?? '0.0.0' });
           },
         );
-        if (rewritten === source) return null;
+
+        if (modified === source) return null;
         const loader = args.path.endsWith('.ts') ? 'ts' : 'js';
-        return { contents: rewritten, loader };
+        return { contents: modified, loader };
       });
     },
   };
@@ -346,7 +388,7 @@ var require = globalThis.__waiaasSeaRequire || require;
   try {
     const { build } = await import('esbuild');
     await build({
-      plugins: [inlinePackageJsonPlugin],
+      plugins: [seaSourcePlugin],
       entryPoints: [join(MONOREPO_ROOT, 'packages/cli/src/index.ts')],
       bundle: true,
       format: 'cjs',


### PR DESCRIPTION
## Summary

v2.14.1-rc.3 still fails on wallet creation: `Cannot find module 'sodium-native'` / `ripple-keypairs`. Issue 493's `natives['sodium-native']` fix was insufficient because daemon source files use `createRequire(import.meta.url)('module')` which creates an independent CJS loader that bypasses both esbuild bundling AND the SEA bootstrap shim.

Two-pronged fix:
1. **esbuild `seaSourcePlugin`**: strips `createRequire(import.meta.url)` at build time so esbuild can statically resolve and bundle all `require()` calls
2. **`Module._load` global patch**: catches remaining dynamic require paths through Node's module system

## Verification (local, before release)

- [x] SEA binary: `POST /v1/wallets` → 201 for ethereum, solana, ripple
- [x] **Tauri .app build**: clean install → daemon up → 3 wallets created via curl against .app daemon
- [ ] CI stage1 + stage2
- [ ] RC DMG clean-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)