### PR TITLE
fix(desktop): skip wizard + default environment mainnet (issue 496)

### DIFF
--- a/internal/objectives/issues/496-desktop-wizard-remove-wallet-step-mainnet-default.md
+++ b/internal/objectives/issues/496-desktop-wizard-remove-wallet-step-mainnet-default.md
@@ -1,0 +1,63 @@
+# 496 — Desktop Setup Wizard 지갑 생성 단계 제거 + 환경 기본값 mainnet 전환
+
+- **유형:** ENHANCEMENT
+- **심각도:** MEDIUM
+- **상태:** FIXED
+- **발견일:** 2026-04-10
+- **발견 경위:** v2.14.1-rc.5 설치 후 대시보드에 testnet 지갑 6개 — wizard와 quickset이 각각 지갑 생성하여 중복, 환경이 모두 testnet
+
+## 문제 2가지
+
+### A. Setup Wizard에서 불필요한 지갑 생성
+
+데몬이 이미 띄워진 상태에서 사용자가 `waiaas quickset`으로 지갑을 만들 수 있는데, Setup Wizard가 추가로 지갑을 만들어서 중복 발생. Desktop 사용자에게는 온보딩을 최대한 빠르게 해야 하므로 지갑 생성 단계가 불필요.
+
+### B. 환경 기본값이 testnet
+
+`packages/core/src/schemas/wallet.schema.ts:35`:
+```ts
+environment: EnvironmentTypeEnum.default('testnet'),
+```
+
+`POST /v1/wallets` 에서 `environment`를 생략하면 testnet이 기본값. Desktop 사용자는 개발자가 아닌 일반 사용자일 확률이 높으므로 **mainnet이 기본**이어야 함. CLI `quickset` 은 이미 `mode ?? 'mainnet'`을 사용하지만, API 스키마 자체가 testnet이라 SDK/MCP 등 다른 호출자도 testnet을 받음.
+
+## 수정 방향
+
+### A. Setup Wizard 완전 제거 → 바로 대시보드
+
+recovery.key auto-login으로 인증이 이미 완료된 상태에서 wizard가 추가로 할 일이 없음:
+- password step: 제거됨 (이슈 491)
+- chain selection + wallet creation: 불필요 (quickset/대시보드에서 관리)
+- owner step: 제거됨 (이슈 495)
+- complete step: 대시보드로 바로 가면 됨
+
+`app.tsx`에서 `isFirstRun()` 체크를 제거하고 auto-login 성공 시 바로 `Layout`(대시보드)로 이동.
+
+`wizard-store.ts`의 `isFirstRun()` 과 `SETUP_COMPLETE_KEY` localStorage flag는 유지 (향후 재사용 가능성), 하지만 wizard UI 자체는 로드하지 않음.
+
+### B. 환경 기본값 mainnet
+
+`packages/core/src/schemas/wallet.schema.ts:35`:
+```diff
+- environment: EnvironmentTypeEnum.default('testnet'),
++ environment: EnvironmentTypeEnum.default('mainnet'),
+```
+
+이렇게 하면:
+- `POST /v1/wallets` 호출 시 `environment` 생략 → mainnet
+- CLI `quickset` — 이미 `mainnet` 명시하므로 영향 없음
+- SDK/MCP — 환경 미지정 시 mainnet (비개발자 기본 경험 개선)
+- 개발자가 testnet 원할 때는 `environment: 'testnet'` 명시
+
+## 테스트 항목
+
+- [ ] Desktop 앱 첫 실행 → Setup Wizard 미표시, 바로 대시보드
+- [ ] `POST /v1/wallets` environment 미지정 시 mainnet 지갑 생성
+- [ ] `POST /v1/wallets` environment: 'testnet' 명시 시 testnet 지갑 생성 (회귀 없음)
+- [ ] CLI `waiaas quickset` 기본 동작 변화 없음 (이미 mainnet)
+- [ ] 로컬 Tauri .app 빌드 → 실행 → 바로 대시보드 도달
+- [ ] `pnpm vitest run src/__tests__/desktop` 통과
+
+## 관련 이슈
+
+- **491** (password step 제거), **492** (chain/wallet 수정), **495** (owner step 제거) — wizard 축소 흐름의 연장

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -40,6 +40,7 @@
 | 493 | BUG | CRITICAL | SEA 데몬에서 sodium-native 직접 require가 지갑 생성 시 MODULE_NOT_FOUND | — | FIXED | 2026-04-09 |
 | 494 | BUG | CRITICAL | SEA shim의 sodium-native intercept가 createRequire 경유 호출을 잡지 못함 | — | FIXED | 2026-04-10 |
 | 495 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard에서 Owner 지갑 연결 단계 제거 | — | FIXED | 2026-04-10 |
+| 496 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard 지갑 생성 단계 제거 + 환경 기본값 mainnet | — | FIXED | 2026-04-10 |
 
 ## Type Legend
 
@@ -53,7 +54,7 @@
 
 - **OPEN:** 0
 - **PLANNED:** 0
-- **FIXED:** 487
+- **FIXED:** 488
 - **WONTFIX:** 1
-- **Total:** 491
+- **Total:** 492
 - **Archived:** 468 (001–468)

--- a/packages/admin/src/app.tsx
+++ b/packages/admin/src/app.tsx
@@ -95,22 +95,11 @@ export function App() {
         }
       }
 
-      // Dynamic import to avoid bundling wizard code in browser builds
-      const { isFirstRun, wizardComplete } = await import('./desktop/wizard/wizard-store');
+      // Issue 496: Setup Wizard removed entirely. Desktop users land on the
+      // dashboard immediately after auto-login. Wallet creation is handled
+      // by `waiaas quickset` or from the dashboard Wallets page.
 
-      if (isFirstRun()) {
-        const { SetupWizard } = await import('./desktop/wizard/setup-wizard');
-        WizardComponent.value = SetupWizard;
-        desktopWizardActive.value = true;
-
-        // Subscribe to wizardComplete changes
-        const dispose = wizardComplete.subscribe((complete) => {
-          wizardCompleteValue.value = complete;
-          if (complete) dispose();
-        });
-      }
-
-      // Load UpdateBanner for auto-update notifications (independent of wizard)
+      // Load UpdateBanner for auto-update notifications
       const { UpdateBanner } = await import('./desktop/UpdateBanner');
       UpdateBannerComponent.value = UpdateBanner;
     })();

--- a/packages/core/src/schemas/wallet.schema.ts
+++ b/packages/core/src/schemas/wallet.schema.ts
@@ -32,7 +32,7 @@ export type Wallet = z.infer<typeof WalletSchema>;
 const CreateWalletRequestBaseSchema = z.object({
   name: z.string().min(1).max(100),
   chain: ChainTypeEnum.default('solana'),
-  environment: EnvironmentTypeEnum.default('testnet'),
+  environment: EnvironmentTypeEnum.default('mainnet'),
   createSession: z.boolean().default(true),
   accountType: AccountTypeEnum.default('eoa'),
   aaProvider: AaProviderNameEnum.optional(),


### PR DESCRIPTION
## Summary

1. **Remove Setup Wizard from Desktop** — auto-login lands directly on the dashboard. Wallet creation handled by \`waiaas quickset\` or the dashboard Wallets page.

2. **Default environment → mainnet** — \`POST /v1/wallets\` schema default changed from \`testnet\` to \`mainnet\`. Desktop users are non-developers who should get mainnet wallets. Explicit \`environment: 'testnet'\` still works.

## Verification (local .app)

- [x] Clean install → no wizard, straight to dashboard (walletCount=0)
- [x] \`POST /v1/wallets\` without environment → \`mainnet\` (\`ethereum-mainnet\`)
- [x] \`POST /v1/wallets\` with \`environment: 'testnet'\` → testnet (no regression)
- [x] 97 desktop tests pass
- [ ] CI stage1 + stage2

🤖 Generated with [Claude Code](https://claude.com/claude-code)