### PR TITLE
feat(desktop): auto-provision 3 mainnet wallets on first boot (issue 497)

### DIFF
--- a/internal/objectives/issues/497-quickset-xrpl-desktop-auto-provision.md
+++ b/internal/objectives/issues/497-quickset-xrpl-desktop-auto-provision.md
@@ -1,0 +1,68 @@
+# 497 — quickset에 XRPL 누락 + Desktop 첫 부팅 시 mainnet 지갑 자동 생성
+
+- **유형:** ENHANCEMENT
+- **심각도:** MEDIUM
+- **상태:** FIXED
+- **발견일:** 2026-04-12
+- **발견 경위:** v2.14.1-rc.6 설치 후 대시보드에 지갑 없음. 수동으로 만들어야 하는 상태.
+
+## 문제 2가지
+
+### A. quickset에 XRPL 누락
+
+`packages/cli/src/commands/quickstart.ts:82-85`:
+```ts
+const chains = [
+  { chain: 'solana', name: `solana-${mode}` },
+  { chain: 'ethereum', name: `evm-${mode}` },
+] as const;
+```
+
+SSoT `CHAIN_TYPES = ['solana', 'ethereum', 'ripple']` 에 ripple이 있지만 quickset이 생성하지 않음.
+
+### B. Desktop 첫 부팅 시 지갑 자동 생성 없음
+
+이슈 496에서 wizard를 제거하면서 지갑 자동 생성 경로도 사라짐. Desktop 사용자가 첫 부팅 후 빈 대시보드를 보고 수동으로 지갑을 만들어야 함. 일반 사용자에게는 "설치 → 바로 사용 가능" 경험이 필요.
+
+## 수정 방향
+
+### A. quickset에 XRPL 추가
+
+```ts
+const chains = [
+  { chain: 'solana', name: `solana-${mode}` },
+  { chain: 'ethereum', name: `evm-${mode}` },
+  { chain: 'ripple', name: `xrpl-${mode}` },
+] as const;
+```
+
+출력 label 도 추가: `ripple` → `XRPL`.
+
+### B. Desktop 첫 부팅 자동 지갑 생성
+
+`app.tsx`의 auto-login 성공 후, `walletCount === 0`이면 3개 mainnet 지갑 자동 생성:
+
+```ts
+// Auto-provision mainnet wallets on first Desktop boot (issue 497)
+if (isDesktop() && data.walletCount === 0) {
+  const chains = ['ethereum', 'solana', 'ripple'];
+  for (const chain of chains) {
+    await fetch(API.WALLETS, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Master-Password': key },
+      body: JSON.stringify({ name: `${label} Wallet`, chain, environment: 'mainnet' }),
+    });
+  }
+}
+```
+
+## 테스트 항목
+
+- [ ] CLI `waiaas quickset` 실행 시 EVM + Solana + XRPL 3개 mainnet 지갑 생성
+- [ ] Desktop 첫 부팅 → auto-login → 3개 mainnet 지갑 자동 생성 → 대시보드에 표시
+- [ ] Desktop 2회차 부팅 → 이미 지갑 있으므로 추가 생성 없음
+- [ ] 로컬 Tauri .app 빌드 → 실행 → 대시보드에 3개 mainnet 지갑 확인
+
+## 관련 이슈
+
+- **496** (wizard 제거) — wizard 제거로 자동 생성 경로 사라짐. 이 이슈가 대체 경로 제공.

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -41,6 +41,7 @@
 | 494 | BUG | CRITICAL | SEA shim의 sodium-native intercept가 createRequire 경유 호출을 잡지 못함 | — | FIXED | 2026-04-10 |
 | 495 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard에서 Owner 지갑 연결 단계 제거 | — | FIXED | 2026-04-10 |
 | 496 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard 지갑 생성 단계 제거 + 환경 기본값 mainnet | — | FIXED | 2026-04-10 |
+| 497 | ENHANCEMENT | MEDIUM | quickset에 XRPL 누락 + Desktop 첫 부팅 mainnet 지갑 자동 생성 | — | FIXED | 2026-04-12 |
 
 ## Type Legend
 
@@ -54,7 +55,7 @@
 
 - **OPEN:** 0
 - **PLANNED:** 0
-- **FIXED:** 488
+- **FIXED:** 489
 - **WONTFIX:** 1
 - **Total:** 492
 - **Archived:** 468 (001–468)

--- a/packages/admin/src/app.tsx
+++ b/packages/admin/src/app.tsx
@@ -84,8 +84,36 @@ export function App() {
             signal: AbortSignal.timeout(10_000),
           });
           if (res.ok) {
-            const data = await res.json().catch(() => ({}));
-            login(recoveryKey, (data as { adminTimeout?: number }).adminTimeout);
+            const data = await res.json().catch(() => ({})) as {
+              adminTimeout?: number;
+              walletCount?: number;
+            };
+            login(recoveryKey, data.adminTimeout);
+
+            // Issue 497: auto-provision mainnet wallets on first Desktop boot.
+            // If the daemon has no wallets yet, create one for each supported
+            // chain (EVM, Solana, XRPL) so the user has a ready-to-use setup.
+            if (data.walletCount === 0) {
+              const CHAINS = [
+                { chain: 'ethereum', name: 'EVM Wallet' },
+                { chain: 'solana', name: 'Solana Wallet' },
+                { chain: 'ripple', name: 'XRP Wallet' },
+              ];
+              for (const { chain, name } of CHAINS) {
+                try {
+                  await fetch(API.WALLETS, {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'X-Master-Password': recoveryKey,
+                    },
+                    body: JSON.stringify({ name, chain, environment: 'mainnet' }),
+                  });
+                } catch {
+                  // Best-effort: continue with remaining chains
+                }
+              }
+            }
           }
           // On 401 we silently fall through to the Login page. The most
           // likely cause is a stale recovery.key after a password change we
@@ -94,10 +122,6 @@ export function App() {
           // Daemon unreachable -- let the Login page handle retries.
         }
       }
-
-      // Issue 496: Setup Wizard removed entirely. Desktop users land on the
-      // dashboard immediately after auto-login. Wallet creation is handled
-      // by `waiaas quickset` or from the dashboard Wallets page.
 
       // Load UpdateBanner for auto-update notifications
       const { UpdateBanner } = await import('./desktop/UpdateBanner');

--- a/packages/cli/src/commands/quickstart.ts
+++ b/packages/cli/src/commands/quickstart.ts
@@ -78,10 +78,11 @@ export async function quickstartCommand(opts: QuickstartOptions): Promise<void> 
   // Step 2: Resolve master password
   const password = opts.masterPassword ?? await resolvePassword(opts.dataDir);
 
-  // Step 3: Create Solana + EVM wallets
+  // Step 3: Create wallets for all supported chains (SSoT: CHAIN_TYPES)
   const chains = [
     { chain: 'solana', name: `solana-${mode}` },
     { chain: 'ethereum', name: `evm-${mode}` },
+    { chain: 'ripple', name: `xrpl-${mode}` },
   ] as const;
 
   const createdWallets: CreatedWallet[] = [];
@@ -206,7 +207,7 @@ export async function quickstartCommand(opts: QuickstartOptions): Promise<void> 
   console.log(`Mode: ${mode}`);
 
   for (const wallet of createdWallets) {
-    const chainLabel = wallet.chain === 'solana' ? 'Solana' : 'EVM';
+    const chainLabel = wallet.chain === 'solana' ? 'Solana' : wallet.chain === 'ripple' ? 'XRPL' : 'EVM';
     console.log('');
     console.log(`${chainLabel} Wallet:`);
     console.log(`  Name: ${wallet.name}`);


### PR DESCRIPTION
## Summary

1. **quickset: add XRPL** — chains array now includes `ripple`, matching SSoT CHAIN_TYPES.
2. **Desktop auto-provision** — after recovery.key auto-login, if `walletCount === 0`, the Admin UI creates EVM/Solana/XRP mainnet wallets automatically. Users see a ready-to-use dashboard on first launch.

## Verification (local .app)

- [x] Clean install → 3 mainnet wallets auto-created (EVM, Solana, XRP)
- [x] Second launch → no duplicate creation (walletCount > 0)
- [ ] CI stage1 + stage2

🤖 Generated with [Claude Code](https://claude.com/claude-code)