### PR TITLE
fix: promote v2.15.0-rc.6 to stable 2.15.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,9 +47,7 @@
     ".": {
       "component": "waiaas",
       "changelog-path": "CHANGELOG.md",
-      "versioning": "prerelease",
-      "prerelease": true,
-      "prerelease-type": "rc",
+      "release-as": "2.15.0",
       "extra-files": [
         "packages/shared/package.json",
         "packages/core/package.json",


### PR DESCRIPTION
Automated promotion of v2.15.0-rc.6 to stable 2.15.0. Merging this PR will trigger release-please to create a stable Release PR.