### PR TITLE
fix(desktop): re-authenticate via recovery.key after session timeout (issue 498)

### DIFF
--- a/internal/objectives/issues/498-desktop-session-timeout-recovery-key-reauth.md
+++ b/internal/objectives/issues/498-desktop-session-timeout-recovery-key-reauth.md
@@ -1,0 +1,41 @@
+# 498 — Desktop 세션 타임아웃 후 recovery.key 재인증 불가
+
+- **유형:** BUG
+- **심각도:** HIGH
+- **상태:** FIXED
+- **관련:** #488, #491, #496, #497
+
+## 현상
+
+Desktop 앱에서 오토프로비저닝으로 첫 부팅 후 일정 시간(기본 15분) 비활성 시:
+
+1. `auth/store.ts`의 `resetInactivityTimer()`가 만료되어 `logout()` 호출
+2. `masterPassword.value = null` → `isAuthenticated = false`
+3. `app.tsx`에서 `<Login />` 컴포넌트 렌더링 → 마스터패스워드 입력 폼 표시
+4. 사용자는 오토프로비저닝으로 부팅했기 때문에 패스워드를 모름 → **진행 불가**
+
+## 원인
+
+`app.tsx:61-130`의 recovery.key 자동 로그인 로직이 최초 마운트 `useEffect([], [])` 에서만 실행됨. 세션 만료 후 `<Login />` 컴포넌트가 렌더링될 때는 recovery.key 재인증을 시도하지 않음.
+
+## 영향 범위
+
+- **Desktop 앱만 해당** — 웹 브라우저 접속 시에는 사용자가 직접 설정한 패스워드로 로그인하므로 문제 없음
+- recovery.key 파일은 디스크에 존재하나 Login 컴포넌트가 이를 활용하지 않음
+
+## 수정 방안
+
+Login 컴포넌트가 마운트될 때 Desktop 환경이면 recovery.key로 자동 재인증 시도:
+
+1. `Login` 컴포넌트 마운트 시 `isDesktop()` 체크
+2. `getDesktopRecoveryKey()` 호출하여 recovery.key 읽기
+3. `/v1/admin/status`로 인증 시도
+4. 성공: `login()` 호출 → 대시보드 이동
+5. 실패: 기존 패스워드 입력 폼 표시 (recovery.key 손상/삭제 시)
+
+## 테스트 항목
+
+- [ ] Desktop 환경에서 세션 타임아웃 후 recovery.key 자동 재인증 성공 확인
+- [ ] recovery.key가 없거나 유효하지 않을 때 기존 로그인 폼 표시 확인
+- [ ] 웹 브라우저 환경에서는 기존 동작(패스워드 폼)이 변경되지 않음 확인
+- [ ] 재인증 중 로딩 상태 표시 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -42,6 +42,7 @@
 | 495 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard에서 Owner 지갑 연결 단계 제거 | — | FIXED | 2026-04-10 |
 | 496 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard 지갑 생성 단계 제거 + 환경 기본값 mainnet | — | FIXED | 2026-04-10 |
 | 497 | ENHANCEMENT | MEDIUM | quickset에 XRPL 누락 + Desktop 첫 부팅 mainnet 지갑 자동 생성 | — | FIXED | 2026-04-12 |
+| 498 | BUG | HIGH | Desktop 세션 타임아웃 후 recovery.key 재인증 불가 | — | FIXED | 2026-04-17 |
 
 ## Type Legend
 
@@ -55,7 +56,7 @@
 
 - **OPEN:** 0
 - **PLANNED:** 0
-- **FIXED:** 489
+- **FIXED:** 490
 - **WONTFIX:** 1
-- **Total:** 492
+- **Total:** 493
 - **Archived:** 468 (001–468)

--- a/packages/admin/src/__tests__/desktop/login-reauth.test.tsx
+++ b/packages/admin/src/__tests__/desktop/login-reauth.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Issue 498: Desktop session timeout recovery.key re-authentication.
+ *
+ * When the Login component mounts inside a Tauri Desktop environment,
+ * it should attempt to re-authenticate using the on-disk recovery.key
+ * before showing the password form.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/preact';
+import { h } from 'preact';
+
+// We need to control isDesktop() and getDesktopRecoveryKey() per test.
+// The Login component imports them at module scope, so we mock the module.
+vi.mock('../../utils/platform', () => ({
+  isDesktop: vi.fn(() => false),
+  getDesktopRecoveryKey: vi.fn(async () => null),
+}));
+
+// Mock auth/store to track login() calls without side-effects
+vi.mock('../../auth/store', () => ({
+  login: vi.fn(),
+  masterPassword: { value: null },
+  isAuthenticated: { value: false },
+}));
+
+import { isDesktop, getDesktopRecoveryKey } from '../../utils/platform';
+import { login } from '../../auth/store';
+
+// Import Login lazily after mocks are in place
+const { Login } = await import('../../auth/login');
+
+const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+describe('Login: Desktop recovery.key re-authentication (issue 498)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should show password form immediately in browser (non-Desktop)', () => {
+    vi.mocked(isDesktop).mockReturnValue(false);
+
+    const { container } = render(<Login />);
+    const input = container.querySelector('input[type="password"]');
+    expect(input).toBeTruthy();
+  });
+
+  it('should show "Reconnecting..." while auto-login is in progress on Desktop', async () => {
+    vi.mocked(isDesktop).mockReturnValue(true);
+    // Make getDesktopRecoveryKey hang to keep the loading state visible
+    vi.mocked(getDesktopRecoveryKey).mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    const { container } = render(<Login />);
+    // Should show reconnecting state, not the password form
+    await waitFor(() => {
+      const text = container.textContent ?? '';
+      expect(text).toContain('Reconnecting');
+    });
+    const input = container.querySelector('input[type="password"]');
+    expect(input).toBeFalsy();
+  });
+
+  it('should auto-login when recovery.key is valid on Desktop', async () => {
+    vi.mocked(isDesktop).mockReturnValue(true);
+    vi.mocked(getDesktopRecoveryKey).mockResolvedValue('abc123recoverykey');
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ adminTimeout: 600 }),
+    } as Response);
+
+    render(<Login />);
+
+    await waitFor(() => {
+      expect(login).toHaveBeenCalledWith('abc123recoverykey', 600);
+    });
+  });
+
+  it('should fall through to password form when recovery.key is missing', async () => {
+    vi.mocked(isDesktop).mockReturnValue(true);
+    vi.mocked(getDesktopRecoveryKey).mockResolvedValue(null);
+
+    const { container } = render(<Login />);
+
+    await waitFor(() => {
+      const input = container.querySelector('input[type="password"]');
+      expect(input).toBeTruthy();
+    });
+  });
+
+  it('should fall through to password form when daemon rejects recovery.key (401)', async () => {
+    vi.mocked(isDesktop).mockReturnValue(true);
+    vi.mocked(getDesktopRecoveryKey).mockResolvedValue('stale-key');
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+    } as Response);
+
+    const { container } = render(<Login />);
+
+    await waitFor(() => {
+      const input = container.querySelector('input[type="password"]');
+      expect(input).toBeTruthy();
+    });
+  });
+
+  it('should fall through to password form when daemon is unreachable', async () => {
+    vi.mocked(isDesktop).mockReturnValue(true);
+    vi.mocked(getDesktopRecoveryKey).mockResolvedValue('abc123');
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { container } = render(<Login />);
+
+    await waitFor(() => {
+      const input = container.querySelector('input[type="password"]');
+      expect(input).toBeTruthy();
+    });
+  });
+});

--- a/packages/admin/src/auth/login.tsx
+++ b/packages/admin/src/auth/login.tsx
@@ -1,10 +1,15 @@
+import { useEffect } from 'preact/hooks';
 import { signal } from '@preact/signals';
 import { login } from './store';
 import { API } from '../api/endpoints';
+import { isDesktop, getDesktopRecoveryKey } from '../utils/platform';
 
 const password = signal('');
 const error = signal<string | null>(null);
 const loading = signal(false);
+
+/** True while Desktop recovery.key auto-login is in progress */
+const desktopAutoLogin = signal(false);
 
 const styles = {
   wrapper: {
@@ -94,6 +99,52 @@ const handleSubmit = async (e: Event) => {
 };
 
 export function Login() {
+  // Issue 498: Desktop recovery.key re-authentication on session timeout.
+  // When the inactivity timer expires, masterPassword is cleared and this
+  // component renders. If running inside Tauri, try the on-disk recovery.key
+  // before showing the password form — the user never set a password so they
+  // can't type one.
+  useEffect(() => {
+    if (!isDesktop()) return;
+
+    desktopAutoLogin.value = true;
+    (async () => {
+      try {
+        const recoveryKey = await getDesktopRecoveryKey();
+        if (!recoveryKey) return;
+
+        const res = await fetch(API.ADMIN_STATUS, {
+          headers: { 'X-Master-Password': recoveryKey },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (res.ok) {
+          const data = await res.json().catch(() => ({})) as {
+            adminTimeout?: number;
+          };
+          login(recoveryKey, data.adminTimeout);
+          return;
+        }
+        // 401 or other — fall through to password form
+      } catch {
+        // Daemon unreachable — show password form
+      } finally {
+        desktopAutoLogin.value = false;
+      }
+    })();
+  }, []);
+
+  // While Desktop auto-login is in progress, show a brief loading state
+  if (desktopAutoLogin.value) {
+    return (
+      <div style={styles.wrapper}>
+        <div style={styles.card}>
+          <h1 style={styles.title}>WAIaaS Admin</h1>
+          <p style={styles.subtitle}>Reconnecting...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div style={styles.wrapper}>
       <form style={styles.card} onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- Desktop 앱에서 세션 타임아웃 후 recovery.key로 자동 재인증하도록 Login 컴포넌트 개선
- 오토프로비저닝 사용자가 비밀번호를 모르는 상태에서 세션 만료 시 진행 불가했던 문제 해결

## Changes
- `packages/admin/src/auth/login.tsx`: Desktop 환경 감지 → recovery.key IPC 읽기 → 자동 인증
- 6개 테스트 케이스, 전체 1095 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)