### PR TITLE
feat(push-relay): add Pushwoosh extra_fields config (issue 499)

### DIFF
--- a/internal/objectives/issues/499-pushwoosh-extra-fields.md
+++ b/internal/objectives/issues/499-pushwoosh-extra-fields.md
@@ -3,7 +3,7 @@
 - **유형:** ENHANCEMENT
 - **심각도:** MEDIUM
 - **발견일:** 2026-04-20
-- **상태:** OPEN
+- **상태:** FIXED
 - **관련 패키지:** @waiaas/push-relay
 
 ## 현상

--- a/internal/objectives/issues/499-pushwoosh-extra-fields.md
+++ b/internal/objectives/issues/499-pushwoosh-extra-fields.md
@@ -1,0 +1,37 @@
+# 499. Pushwoosh Notification Extra Fields 지원
+
+- **유형:** ENHANCEMENT
+- **심각도:** MEDIUM
+- **발견일:** 2026-04-20
+- **상태:** OPEN
+- **관련 패키지:** @waiaas/push-relay
+
+## 현상
+
+디센트팀 요청: Pushwoosh 푸시 알림 payload에 `link: '/waiaas'` 딥링크 필드가 필요.
+현재 PushwooshProvider는 notification object에 고정 필드만 포함하며, 추가 필드를 주입할 방법이 없음.
+
+## 원인
+
+PushwooshProvider가 notification payload를 하드코딩된 필드만으로 구성하고 있어 Pushwoosh API가 지원하는 추가 필드(link, campaign, minimize_link 등)를 활용할 수 없음.
+
+## 해결 방안
+
+PushwooshConfig에 `extra_fields` (Record<string, unknown>) 옵션을 추가하여 config.toml에서 임의의 key-value를 설정하면 notification payload에 spread되도록 구현.
+
+```toml
+[pushwoosh.extra_fields]
+link = "/waiaas"
+```
+
+## 영향 범위
+
+- `packages/push-relay/src/config.ts` — PushwooshConfig 스키마에 extra_fields 추가
+- `packages/push-relay/src/providers/pushwoosh-provider.ts` — notification에 extraFields spread
+- `packages/push-relay/src/__tests__/pushwoosh-provider.test.ts` — 테스트 추가
+
+## 테스트 항목
+
+- [ ] extra_fields 설정 시 notification payload에 해당 필드가 포함되는지 확인
+- [ ] extra_fields 미설정 시 기존 동작과 동일한지 확인
+- [ ] 다수의 extra_fields가 올바르게 spread되는지 확인

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -43,7 +43,7 @@
 | 496 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard 지갑 생성 단계 제거 + 환경 기본값 mainnet | — | FIXED | 2026-04-10 |
 | 497 | ENHANCEMENT | MEDIUM | quickset에 XRPL 누락 + Desktop 첫 부팅 mainnet 지갑 자동 생성 | — | FIXED | 2026-04-12 |
 | 498 | BUG | HIGH | Desktop 세션 타임아웃 후 recovery.key 재인증 불가 | — | FIXED | 2026-04-17 |
-| 499 | ENHANCEMENT | MEDIUM | Pushwoosh notification extra_fields 설정 지원 | — | OPEN | — |
+| 499 | ENHANCEMENT | MEDIUM | Pushwoosh notification extra_fields 설정 지원 | — | FIXED | 2026-04-21 |
 
 ## Type Legend
 
@@ -55,9 +55,9 @@
 
 ## Summary
 
-- **OPEN:** 1
+- **OPEN:** 0
 - **PLANNED:** 0
-- **FIXED:** 490
+- **FIXED:** 491
 - **WONTFIX:** 1
 - **Total:** 493
 - **Archived:** 468 (001–468)

--- a/internal/objectives/issues/TRACKER.md
+++ b/internal/objectives/issues/TRACKER.md
@@ -43,6 +43,7 @@
 | 496 | ENHANCEMENT | MEDIUM | Desktop Setup Wizard 지갑 생성 단계 제거 + 환경 기본값 mainnet | — | FIXED | 2026-04-10 |
 | 497 | ENHANCEMENT | MEDIUM | quickset에 XRPL 누락 + Desktop 첫 부팅 mainnet 지갑 자동 생성 | — | FIXED | 2026-04-12 |
 | 498 | BUG | HIGH | Desktop 세션 타임아웃 후 recovery.key 재인증 불가 | — | FIXED | 2026-04-17 |
+| 499 | ENHANCEMENT | MEDIUM | Pushwoosh notification extra_fields 설정 지원 | — | OPEN | — |
 
 ## Type Legend
 
@@ -54,7 +55,7 @@
 
 ## Summary
 
-- **OPEN:** 0
+- **OPEN:** 1
 - **PLANNED:** 0
 - **FIXED:** 490
 - **WONTFIX:** 1

--- a/packages/push-relay/config.example.toml
+++ b/packages/push-relay/config.example.toml
@@ -12,6 +12,11 @@ api_token = "XXXXXX-XXXXXX"
 application_code = "ABCDE-12345"
 # api_url = "https://api.pushwoosh.com/json/1.3/createMessage"  # default; override for Private Cloud
 
+# Extra fields injected into the Pushwoosh notification object
+# [relay.push.pushwoosh.extra_fields]
+# link = "/waiaas"
+# campaign = "onboarding"
+
 # Or use FCM:
 # [relay.push.fcm]
 # project_id = "my-wallet-app"

--- a/packages/push-relay/src/__tests__/pushwoosh-provider.test.ts
+++ b/packages/push-relay/src/__tests__/pushwoosh-provider.test.ts
@@ -145,6 +145,47 @@ describe('PushwooshProvider', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('includes extra_fields in notification payload', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status_code: 200, status_message: 'OK' }),
+    });
+
+    const provider = new PushwooshProvider({
+      api_token: 'test-token',
+      application_code: 'APP-123',
+      api_url: DEFAULT_API_URL,
+      extra_fields: { link: '/waiaas', campaign: 'onboarding' },
+    });
+
+    await provider.send(['device-1'], mockPayload);
+    const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    const body = JSON.parse(fetchCall[1]!.body as string);
+    const notification = body.request.notifications[0];
+    expect(notification.link).toBe('/waiaas');
+    expect(notification.campaign).toBe('onboarding');
+  });
+
+  it('works without extra_fields (backwards compatible)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status_code: 200, status_message: 'OK' }),
+    });
+
+    const provider = new PushwooshProvider({
+      api_token: 'test-token',
+      application_code: 'APP-123',
+      api_url: DEFAULT_API_URL,
+    });
+
+    await provider.send(['device-1'], mockPayload);
+    const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    const body = JSON.parse(fetchCall[1]!.body as string);
+    const notification = body.request.notifications[0];
+    expect(notification.link).toBeUndefined();
+    expect(notification.content).toBe('TRANSFER 1 SOL');
+  });
+
   it('validates config checks token and code length', async () => {
     const valid = new PushwooshProvider({ api_token: 'tok', application_code: 'code', api_url: DEFAULT_API_URL });
     expect(await valid.validateConfig()).toBe(true);

--- a/packages/push-relay/src/config.ts
+++ b/packages/push-relay/src/config.ts
@@ -6,6 +6,7 @@ const PushwooshConfigSchema = z.object({
   api_token: z.string().min(1),
   application_code: z.string().min(1),
   api_url: z.string().url().default('https://api.pushwoosh.com/json/1.3/createMessage'),
+  extra_fields: z.record(z.string(), z.unknown()).default({}),
 });
 
 const FcmConfigSchema = z.object({

--- a/packages/push-relay/src/providers/pushwoosh-provider.ts
+++ b/packages/push-relay/src/providers/pushwoosh-provider.ts
@@ -8,11 +8,13 @@ export class PushwooshProvider implements IPushProvider {
   private readonly apiToken: string;
   private readonly applicationCode: string;
   private readonly apiUrl: string;
+  private readonly extraFields: Record<string, unknown>;
 
   constructor(config: PushwooshConfig) {
     this.apiToken = config.api_token;
     this.applicationCode = config.application_code;
     this.apiUrl = config.api_url;
+    this.extraFields = config.extra_fields ?? {};
   }
 
   async send(tokens: string[], payload: PushPayload): Promise<PushResult> {
@@ -31,6 +33,7 @@ export class PushwooshProvider implements IPushProvider {
             send_date: 'now',
             content: payload.body,
             data: payload.data,
+            ...this.extraFields,
             devices: tokens,
             ios_root_params: {
               aps: {


### PR DESCRIPTION
## Summary
- Add `extra_fields` option to `[relay.push.pushwoosh]` config for injecting arbitrary fields into the Pushwoosh notification payload
- Enables deep-link support (e.g. `link = "/waiaas"`) requested by D'CENT team without code changes
- Backwards compatible — omitting `extra_fields` preserves existing behavior

## Changes
- `packages/push-relay/src/config.ts` — `extra_fields: z.record(z.string(), z.unknown()).default({})`
- `packages/push-relay/src/providers/pushwoosh-provider.ts` — spread `extraFields` into notification object
- `packages/push-relay/config.example.toml` — usage example
- 2 new tests (with/without extra_fields)

## Usage
```toml
[relay.push.pushwoosh.extra_fields]
link = "/waiaas"
campaign = "onboarding"
```

## Test plan
- [x] extra_fields included in notification payload
- [x] Backwards compatible without extra_fields
- [x] All 109 push-relay tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)