### PR TITLE
fix(push-relay): make extra_fields optional in constructor

### DIFF
--- a/packages/push-relay/src/config.ts
+++ b/packages/push-relay/src/config.ts
@@ -6,7 +6,7 @@ const PushwooshConfigSchema = z.object({
   api_token: z.string().min(1),
   application_code: z.string().min(1),
   api_url: z.string().url().default('https://api.pushwoosh.com/json/1.3/createMessage'),
-  extra_fields: z.record(z.string(), z.unknown()).default({}),
+  extra_fields: z.record(z.string(), z.unknown()).optional().default({}),
 });
 
 const FcmConfigSchema = z.object({

--- a/packages/push-relay/src/providers/pushwoosh-provider.ts
+++ b/packages/push-relay/src/providers/pushwoosh-provider.ts
@@ -10,7 +10,7 @@ export class PushwooshProvider implements IPushProvider {
   private readonly apiUrl: string;
   private readonly extraFields: Record<string, unknown>;
 
-  constructor(config: PushwooshConfig) {
+  constructor(config: Omit<PushwooshConfig, 'extra_fields'> & { extra_fields?: Record<string, unknown> }) {
     this.apiToken = config.api_token;
     this.applicationCode = config.application_code;
     this.apiUrl = config.api_url;


### PR DESCRIPTION
## Summary
- Fix typecheck failure from PR #385 where `extra_fields` was required in `PushwooshProvider` constructor signature
- Constructor now accepts `extra_fields` as optional, matching the Zod schema's `.default({})` behavior

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 109 push-relay tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)