### PR TITLE
fix: promote v2.16.0-rc to stable 2.16.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,9 +47,7 @@
     ".": {
       "component": "waiaas",
       "changelog-path": "CHANGELOG.md",
-      "versioning": "prerelease",
-      "prerelease": true,
-      "prerelease-type": "rc",
+      "release-as": "2.16.0",
       "extra-files": [
         "packages/shared/package.json",
         "packages/core/package.json",


### PR DESCRIPTION
Automated promotion of v2.16.0-rc to stable 2.16.0. Merging this PR will trigger release-please to create a stable Release PR.