### PR TITLE
chore: restore prerelease mode

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,7 +47,9 @@
     ".": {
       "component": "waiaas",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "2.16.0",
+      "versioning": "prerelease",
+      "prerelease": true,
+      "prerelease-type": "rc",
       "extra-files": [
         "packages/shared/package.json",
         "packages/core/package.json",


### PR DESCRIPTION
Automated restore of prerelease mode after v2.16.0 stable release deployment.